### PR TITLE
include gcp apis in the sample configs

### DIFF
--- a/.github/actions/license-check/action.yaml
+++ b/.github/actions/license-check/action.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: "License Check Action"
 description: "Check License Headers"
 outputs:

--- a/.github/actions/tftest/action.yaml
+++ b/.github/actions/tftest/action.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: "TFtest Action"
 description: "Runs a Terraform Test Suite"
 inputs:

--- a/.github/actions/update-docs/action.yaml
+++ b/.github/actions/update-docs/action.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: "Update Docs"
 description: "Updates the TF Module documentation if needed"
 outputs:

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: Check Docs
 on:
   pull_request:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: License Check
 on:
   push:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: Code Linter
 on:
   push:

--- a/.github/workflows/test-samples.yml
+++ b/.github/workflows/test-samples.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: TF Samples Test
 on:
   push:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*       @seymen @danistrebel
+*       @danistrebel
 
 modules/apigee-x-bridge-mig             @danistrebel
 modules/apigee-x-core                   @danistrebel
@@ -9,3 +9,4 @@ modules/nip-development-hostname        @danistrebel
 samples/x-basic                         @danistrebel
 samples/x-ilb-mtls                      @danistrebel
 samples/x-l7xlb                         @danistrebel
+samples/x-transitive-peering            @danistrebel

--- a/README.md
+++ b/README.md
@@ -17,12 +17,10 @@ Currently the following modules are a available and can be used either as part o
 
 ## Deploying End-To-End Samples
 
-Set the project and enable all required services:
+Set the project ID where you want your Apigee Organization to be deployed to:
 
 ```sh
 PROJECT_ID=my-project-id
-
-gcloud services enable compute.googleapis.com apigee.googleapis.com servicenetworking.googleapis.com cloudkms.googleapis.com --project $PROJECT_ID
 ```
 
 Select one of the available sample deployments:

--- a/samples/x-basic/README.md
+++ b/samples/x-basic/README.md
@@ -15,6 +15,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v8.0.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v8.0.0 |
 
 ## Resources
@@ -29,9 +30,12 @@ No resources.
 | <a name="input_apigee_environments"></a> [apigee\_environments](#input\_apigee\_environments) | List of Apigee Environment Names. | `list(string)` | `[]` | no |
 | <a name="input_apigee_instances"></a> [apigee\_instances](#input\_apigee\_instances) | Apigee Instances (only one instance for EVAL orgs). | <pre>map(object({<br>    region       = string<br>    cidr_mask    = number<br>    environments = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_ax_region"></a> [ax\_region](#input\_ax\_region) | GCP region for storing Apigee analytics data (see https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli). | `string` | n/a | yes |
+| <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | Billing account id. | `string` | `null` | no |
 | <a name="input_network"></a> [network](#input\_network) | Name of the VPC network to peer with the Apigee tennant project. | `string` | n/a | yes |
 | <a name="input_peering_range"></a> [peering\_range](#input\_peering\_range) | Service Peering CIDR range. | `string` | n/a | yes |
+| <a name="input_project_create"></a> [project\_create](#input\_project\_create) | Create project. When set to false, uses a data source to reference existing project. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id (also used for the Apigee Organization). | `string` | n/a | yes |
+| <a name="input_project_parent"></a> [project\_parent](#input\_project\_parent) | Parent folder or organization in 'folders/folder\_id' or 'organizations/org\_id' format. | `string` | `null` | no |
 
 ## Outputs
 

--- a/samples/x-basic/main.tf
+++ b/samples/x-basic/main.tf
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
+module "project" {
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v8.0.0"
+  name            = var.project_id
+  parent          = var.project_parent
+  billing_account = var.billing_account
+  project_create  = var.project_create
+  services = [
+    "apigee.googleapis.com",
+    "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "servicenetworking.googleapis.com"
+  ]
+}
+
 module "vpc" {
   source                           = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v8.0.0"
-  project_id                       = var.project_id
+  project_id                       = module.project.project_id
   name                             = var.network
   subnets                          = []
   private_service_networking_range = var.peering_range
@@ -24,10 +38,11 @@ module "vpc" {
 
 module "apigee-x-core" {
   source              = "../../modules/apigee-x-core"
-  project_id          = var.project_id
+  project_id          = module.project.project_id
   apigee_environments = var.apigee_environments
   ax_region           = var.ax_region
   apigee_envgroups    = var.apigee_envgroups
   network             = module.vpc.network.id
   apigee_instances    = var.apigee_instances
 }
+

--- a/samples/x-basic/variables.tf
+++ b/samples/x-basic/variables.tf
@@ -58,3 +58,25 @@ variable "peering_range" {
   description = "Service Peering CIDR range."
   type        = string
 }
+
+variable "billing_account" {
+  description = "Billing account id."
+  type        = string
+  default     = null
+}
+
+variable "project_parent" {
+  description = "Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.project_parent == null || can(regex("(organizations|folders)/[0-9]+", var.project_parent))
+    error_message = "Parent must be of the form folders/folder_id or organizations/organization_id."
+  }
+}
+
+variable "project_create" {
+  description = "Create project. When set to false, uses a data source to reference existing project."
+  type        = bool
+  default     = false
+}

--- a/samples/x-ilb-mtls/README.md
+++ b/samples/x-ilb-mtls/README.md
@@ -17,6 +17,7 @@ No providers.
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_apigee-x-mtls-mig"></a> [apigee-x-mtls-mig](#module\_apigee-x-mtls-mig) | ../../modules/apigee-x-mtls-mig | n/a |
 | <a name="module_ilb"></a> [ilb](#module\_ilb) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-ilb | v8.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v8.0.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v8.0.0 |
 
 ## Resources
@@ -31,11 +32,14 @@ No resources.
 | <a name="input_apigee_environments"></a> [apigee\_environments](#input\_apigee\_environments) | Apigee Environment Names. | `list(string)` | `[]` | no |
 | <a name="input_apigee_instances"></a> [apigee\_instances](#input\_apigee\_instances) | Apigee Instances (only one for EVAL). | <pre>map(object({<br>    region       = string<br>    cidr_mask    = number<br>    environments = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_ax_region"></a> [ax\_region](#input\_ax\_region) | GCP region for storing Apigee analytics data (see https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli). | `string` | n/a | yes |
+| <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | Billing account id. | `string` | `null` | no |
 | <a name="input_ca_cert_path"></a> [ca\_cert\_path](#input\_ca\_cert\_path) | Path to User CA Cert File (pem). | `string` | n/a | yes |
 | <a name="input_exposure_subnets"></a> [exposure\_subnets](#input\_exposure\_subnets) | Subnets for exposing Apigee services. | <pre>list(object({<br>    name               = string<br>    ip_cidr_range      = string<br>    region             = string<br>    secondary_ip_range = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_network"></a> [network](#input\_network) | VPC name. | `string` | n/a | yes |
 | <a name="input_peering_range"></a> [peering\_range](#input\_peering\_range) | Peering CIDR range | `string` | n/a | yes |
+| <a name="input_project_create"></a> [project\_create](#input\_project\_create) | Create project. When set to false, uses a data source to reference existing project. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id (also used for the Apigee Organization). | `string` | n/a | yes |
+| <a name="input_project_parent"></a> [project\_parent](#input\_project\_parent) | Parent folder or organization in 'folders/folder\_id' or 'organizations/org\_id' format. | `string` | `null` | no |
 | <a name="input_tls_cert_path"></a> [tls\_cert\_path](#input\_tls\_cert\_path) | Path to Server Cert File (pem). | `string` | n/a | yes |
 | <a name="input_tls_key_path"></a> [tls\_key\_path](#input\_tls\_key\_path) | Path to Server Key File (pem). | `string` | n/a | yes |
 

--- a/samples/x-ilb-mtls/variables.tf
+++ b/samples/x-ilb-mtls/variables.tf
@@ -84,3 +84,25 @@ variable "tls_key_path" {
   description = "Path to Server Key File (pem)."
   type        = string
 }
+
+variable "billing_account" {
+  description = "Billing account id."
+  type        = string
+  default     = null
+}
+
+variable "project_parent" {
+  description = "Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.project_parent == null || can(regex("(organizations|folders)/[0-9]+", var.project_parent))
+    error_message = "Parent must be of the form folders/folder_id or organizations/organization_id."
+  }
+}
+
+variable "project_create" {
+  description = "Create project. When set to false, uses a data source to reference existing project."
+  type        = bool
+  default     = false
+}

--- a/samples/x-l7xlb/README.md
+++ b/samples/x-l7xlb/README.md
@@ -18,6 +18,7 @@ No providers.
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v8.0.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v8.0.0 |
 
 ## Resources
@@ -32,10 +33,13 @@ No resources.
 | <a name="input_apigee_environments"></a> [apigee\_environments](#input\_apigee\_environments) | Apigee Environment Names. | `list(string)` | `[]` | no |
 | <a name="input_apigee_instances"></a> [apigee\_instances](#input\_apigee\_instances) | Apigee Instances (only one for EVAL). | <pre>map(object({<br>    region       = string<br>    cidr_mask    = number<br>    environments = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_ax_region"></a> [ax\_region](#input\_ax\_region) | GCP region for storing Apigee analytics data (see https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli). | `string` | n/a | yes |
+| <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | Billing account id. | `string` | `null` | no |
 | <a name="input_exposure_subnets"></a> [exposure\_subnets](#input\_exposure\_subnets) | Subnets for exposing Apigee services | <pre>list(object({<br>    name               = string<br>    ip_cidr_range      = string<br>    region             = string<br>    secondary_ip_range = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_network"></a> [network](#input\_network) | VPC name. | `string` | n/a | yes |
 | <a name="input_peering_range"></a> [peering\_range](#input\_peering\_range) | Peering CIDR range | `string` | n/a | yes |
+| <a name="input_project_create"></a> [project\_create](#input\_project\_create) | Create project. When set to false, uses a data source to reference existing project. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id (also used for the Apigee Organization). | `string` | n/a | yes |
+| <a name="input_project_parent"></a> [project\_parent](#input\_project\_parent) | Parent folder or organization in 'folders/folder\_id' or 'organizations/org\_id' format. | `string` | `null` | no |
 
 ## Outputs
 

--- a/samples/x-l7xlb/main.tf
+++ b/samples/x-l7xlb/main.tf
@@ -20,9 +20,23 @@ locals {
   }
 }
 
+module "project" {
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v8.0.0"
+  name            = var.project_id
+  parent          = var.project_parent
+  billing_account = var.billing_account
+  project_create  = var.project_create
+  services = [
+    "apigee.googleapis.com",
+    "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "servicenetworking.googleapis.com"
+  ]
+}
+
 module "vpc" {
   source                           = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v8.0.0"
-  project_id                       = var.project_id
+  project_id                       = module.project.project_id
   name                             = var.network
   private_service_networking_range = var.peering_range
   subnets                          = var.exposure_subnets
@@ -30,14 +44,14 @@ module "vpc" {
 
 module "nip-development-hostname" {
   source             = "../../modules/nip-development-hostname"
-  project_id         = var.project_id
+  project_id         = module.project.project_id
   address_name       = "apigee-external"
   subdomain_prefixes = [for name, _ in var.apigee_envgroups : name]
 }
 
 module "apigee-x-core" {
   source              = "../../modules/apigee-x-core"
-  project_id          = var.project_id
+  project_id          = module.project.project_id
   ax_region           = var.ax_region
   apigee_instances    = var.apigee_instances
   apigee_environments = var.apigee_environments
@@ -53,7 +67,7 @@ module "apigee-x-core" {
 module "apigee-x-bridge-mig" {
   for_each    = var.apigee_instances
   source      = "../../modules/apigee-x-bridge-mig"
-  project_id  = var.project_id
+  project_id  = module.project.project_id
   network     = module.vpc.network.id
   subnet      = module.vpc.subnet_self_links[local.subnet_region_name[each.value.region]]
   region      = each.value.region
@@ -62,7 +76,7 @@ module "apigee-x-bridge-mig" {
 
 module "mig-l7xlb" {
   source          = "../../modules/mig-l7xlb"
-  project_id      = var.project_id
+  project_id      = module.project.project_id
   name            = "apigee-xlb"
   backend_migs    = [for _, mig in module.apigee-x-bridge-mig : mig.instance_group]
   ssl_certificate = module.nip-development-hostname.ssl_certificate

--- a/samples/x-l7xlb/variables.tf
+++ b/samples/x-l7xlb/variables.tf
@@ -69,3 +69,25 @@ variable "peering_range" {
   description = "Peering CIDR range"
   type        = string
 }
+
+variable "billing_account" {
+  description = "Billing account id."
+  type        = string
+  default     = null
+}
+
+variable "project_parent" {
+  description = "Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.project_parent == null || can(regex("(organizations|folders)/[0-9]+", var.project_parent))
+    error_message = "Parent must be of the form folders/folder_id or organizations/organization_id."
+  }
+}
+
+variable "project_create" {
+  description = "Create project. When set to false, uses a data source to reference existing project."
+  type        = bool
+  default     = false
+}

--- a/samples/x-transitive-peering/README.md
+++ b/samples/x-transitive-peering/README.md
@@ -39,6 +39,7 @@ for detailed instructions.
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/httpbin-development-backend | n/a |
 | <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v8.0.0 |
 | <a name="module_peering-apigee-backend"></a> [peering-apigee-backend](#module\_peering-apigee-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering | v8.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v8.0.0 |
 | <a name="module_routing-appliance"></a> [routing-appliance](#module\_routing-appliance) | ../../modules/routing-appliance | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v8.0.0 |
 
@@ -67,8 +68,11 @@ for detailed instructions.
 | <a name="input_backend_network"></a> [backend\_network](#input\_backend\_network) | Peered Backend VPC name. | `string` | n/a | yes |
 | <a name="input_backend_region"></a> [backend\_region](#input\_backend\_region) | GCP Region Backend (ensure this matches backend\_subnet.region). | `string` | n/a | yes |
 | <a name="input_backend_subnet"></a> [backend\_subnet](#input\_backend\_subnet) | Subnet to host the backend service | <pre>object({<br>    name               = string<br>    ip_cidr_range      = string<br>    region             = string<br>    secondary_ip_range = map(string)<br>  })</pre> | n/a | yes |
+| <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | Billing account id. | `string` | `null` | no |
 | <a name="input_peering_range"></a> [peering\_range](#input\_peering\_range) | Peering CIDR range | `string` | n/a | yes |
+| <a name="input_project_create"></a> [project\_create](#input\_project\_create) | Create project. When set to false, uses a data source to reference existing project. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id (also used for the Apigee Organization). | `string` | n/a | yes |
+| <a name="input_project_parent"></a> [project\_parent](#input\_project\_parent) | Parent folder or organization in 'folders/folder\_id' or 'organizations/org\_id' format. | `string` | `null` | no |
 
 ## Outputs
 

--- a/samples/x-transitive-peering/main.tf
+++ b/samples/x-transitive-peering/main.tf
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
+module "project" {
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v8.0.0"
+  name            = var.project_id
+  parent          = var.project_parent
+  billing_account = var.billing_account
+  project_create  = var.project_create
+  services = [
+    "apigee.googleapis.com",
+    "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "servicenetworking.googleapis.com"
+  ]
+}
+
 module "vpc" {
   source                           = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v8.0.0"
-  project_id                       = var.project_id
+  project_id                       = module.project.project_id
   name                             = var.apigee_network
   private_service_networking_range = var.peering_range
   subnets                          = [var.appliance_subnet]
@@ -24,7 +38,7 @@ module "vpc" {
 
 module "apigee-x-core" {
   source              = "../../modules/apigee-x-core"
-  project_id          = var.project_id
+  project_id          = module.project.project_id
   ax_region           = var.ax_region
   apigee_instances    = var.apigee_instances
   apigee_environments = var.apigee_environments
@@ -38,7 +52,7 @@ module "apigee-x-core" {
 }
 
 resource "google_compute_network_peering_routes_config" "peering_primary_routes" {
-  project              = var.project_id
+  project              = module.project.project_id
   peering              = "servicenetworking-googleapis-com"
   network              = module.vpc.name
   import_custom_routes = false
@@ -47,7 +61,7 @@ resource "google_compute_network_peering_routes_config" "peering_primary_routes"
 
 module "routing-appliance" {
   source           = "../../modules/routing-appliance"
-  project_id       = var.project_id
+  project_id       = module.project.project_id
   name             = var.appliance_name
   network          = module.vpc.name
   subnet           = module.vpc.subnet_self_links["${var.appliance_subnet.region}/${var.appliance_subnet.name}"]
@@ -57,7 +71,7 @@ module "routing-appliance" {
 
 resource "google_compute_firewall" "allow-appliance-ingress" {
   name          = "allow-appliance-ingress"
-  project       = var.project_id
+  project       = module.project.project_id
   network       = module.vpc.self_link
   source_ranges = [var.peering_range, var.backend_subnet.ip_cidr_range]
   target_tags   = [var.appliance_name]
@@ -69,7 +83,7 @@ resource "google_compute_firewall" "allow-appliance-ingress" {
 
 module "backend-vpc" {
   source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v8.0.0"
-  project_id = var.project_id
+  project_id = module.project.project_id
   name       = var.backend_network
   subnets    = [var.backend_subnet]
 }
@@ -90,7 +104,7 @@ module "peering-apigee-backend" {
 
 module "backend-example" {
   source     = "../../modules/httpbin-development-backend"
-  project_id = var.project_id
+  project_id = module.project.project_id
   name       = var.backend_name
   network    = var.backend_network
   subnet     = module.backend-vpc.subnet_self_links["${var.backend_subnet.region}/${var.backend_subnet.name}"]
@@ -99,7 +113,7 @@ module "backend-example" {
 
 resource "google_compute_firewall" "allow-backend-ingress" {
   name          = "allow-backend-ingress"
-  project       = var.project_id
+  project       = module.project.project_id
   network       = module.backend-vpc.self_link
   source_ranges = [var.appliance_subnet.ip_cidr_range]
   target_tags   = [var.backend_name]

--- a/samples/x-transitive-peering/variables.tf
+++ b/samples/x-transitive-peering/variables.tf
@@ -113,3 +113,25 @@ variable "peering_range" {
   description = "Peering CIDR range"
   type        = string
 }
+
+variable "billing_account" {
+  description = "Billing account id."
+  type        = string
+  default     = null
+}
+
+variable "project_parent" {
+  description = "Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.project_parent == null || can(regex("(organizations|folders)/[0-9]+", var.project_parent))
+    error_message = "Parent must be of the form folders/folder_id or organizations/organization_id."
+  }
+}
+
+variable "project_create" {
+  description = "Create project. When set to false, uses a data source to reference existing project."
+  type        = bool
+  default     = false
+}

--- a/tests/samples/test_ilb_mtls.py
+++ b/tests/samples/test_ilb_mtls.py
@@ -26,13 +26,14 @@ def resources(recursive_plan_runner):
         FIXTURES_DIR,
         tf_var_file=os.path.join(FIXTURES_DIR, "x-demo.tfvars"),
         project_id="testonly",
+        project_create="true"
     )
     return resources
 
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 34
+    assert len(resources) == 39
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_l7xlb.py
+++ b/tests/samples/test_l7xlb.py
@@ -26,13 +26,14 @@ def resources(recursive_plan_runner):
         FIXTURES_DIR,
         tf_var_file=os.path.join(FIXTURES_DIR, "x-demo.tfvars"),
         project_id="testonly",
+        project_create="true"
     )
     return resources
 
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 33
+    assert len(resources) == 38
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_transtive_peering.py
+++ b/tests/samples/test_transtive_peering.py
@@ -28,13 +28,14 @@ def resources(recursive_plan_runner):
         FIXTURES_DIR,
         tf_var_file=os.path.join(FIXTURES_DIR, "x-demo.tfvars"),
         project_id="testonly",
+        project_create="true"
     )
     return resources
 
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 47
+    assert len(resources) == 52
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_x_basic.py
+++ b/tests/samples/test_x_basic.py
@@ -26,13 +26,14 @@ def resources(recursive_plan_runner):
         FIXTURES_DIR,
         tf_var_file=os.path.join(FIXTURES_DIR, "x-demo.tfvars"),
         project_id="testonly",
+        project_create="true"
     )
     return resources
 
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 19
+    assert len(resources) == 24
 
 
 def test_apigee_instance(resources):


### PR DESCRIPTION
What's changed, or what was fixed?

- GCP apis are enabled via tf resources for each sample
- Updated tests to include new resources

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.