### PR TITLE
explicitly add allow firewall for SB PSC demo backend

### DIFF
--- a/samples/x-sb-psc/README.md
+++ b/samples/x-sb-psc/README.md
@@ -39,6 +39,7 @@ psc_endpoint_attachment_host = "7.0.5.2"
 
 | Name | Type |
 |------|------|
+| [google_compute_firewall.allow_psc_nat_to_backend](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_subnetwork.psc_nat_subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
 
 ## Inputs

--- a/tests/samples/test_sb_psc.py
+++ b/tests/samples/test_sb_psc.py
@@ -34,7 +34,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 40
+    assert len(resources) == 41
 
 
 def test_apigee_instance(resources):


### PR DESCRIPTION
What's changed, or what was fixed?

- Firewall for SB psc demo backend for HTTP(S) traffic from the PSC NAT subnet.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.