### PR TITLE
Automate Releases & Versioning

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -49,3 +49,13 @@ jobs:
           TERRAFORM_TERRASCAN_DISABLE_ERRORS: true
           MARKDOWN_MARKDOWN_LINK_CHECK_FILTER_REGEX_EXCLUDE: 'CONTRIBUTING.md'
           LINTER_RULES_PATH: '.'
+  commitlint:
+    name: Conventional Commits Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+        with:
+          failOnWarnings: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: release-workflow
+name: Release Please
 on:
   push:
     branches:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: release-workflow
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: terraform-module
+          package-name: apigee-terraform-modules

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Release Please
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,14 @@ information on using pull requests.
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Commits
+
+All commit messages should adhere to the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standards.
+
+e.g.
+
+`feat: Added New Feature`
+
+Would indicate a new feature and a minor [SemVer](https://semver.org/) version increase.


### PR DESCRIPTION
What's changed, or what was fixed?

- Added [Release Please action](https://github.com/google-github-actions/release-please-action) to automate release creation and versioning 
- Added liniting for Conventional Commits

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.