### PR TITLE
ci: use bot credentials for release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,10 @@ jobs:
   release-please:
     name: Create Release
     runs-on: ubuntu-latest
+    environment: tf_modules
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
           release-type: terraform-module
           package-name: apigee-terraform-modules


### PR DESCRIPTION
What's changed, or what was fixed?

- use bot credentials for release-please-action

**Fixes:** #38 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.