### PR TITLE
minor fix in sample code

### DIFF
--- a/modules/apigee-x-mtls-mig/envoy-config-template.yaml
+++ b/modules/apigee-x-mtls-mig/envoy-config-template.yaml
@@ -29,6 +29,8 @@ static_resources:
                   subject: true
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 route_config:
                   name: local_route
                   virtual_hosts:


### PR DESCRIPTION
- Envoy configuration in sample code seems to be out of date

**Fixes:** #issue

- Added 
 typed_config: "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
