### PR TITLE
fix: wip add region shorthands for bridge mig module

### DIFF
--- a/modules/apigee-x-bridge-mig/main.tf
+++ b/modules/apigee-x-bridge-mig/main.tf
@@ -15,7 +15,16 @@
  */
 
 locals {
-  bridge_name = var.name == null ? "apigee-${var.region}" : var.name
+  region_shorthand = {
+    "northamerica-northeast1" = "nrtam-nrteast1",
+    "northamerica-northeast2" = "nrtam-nrteast2",
+    "southamerica-west1"      = "stham-west1",
+    "southamerica-east1"      = "stham-east1",
+    "europe-southwest1"       = "europe-sthwest1",
+    "australia-southeast1"    = "au-stheast1",
+    "australia-southeast2"    = "au-stheast2"
+  } # Shorthands for regions with long names.
+  bridge_name = var.name == null ? "apigee-${lookup(local.region_shorthand, var.region)}" : var.name
 }
 
 module "bridge-template" {


### PR DESCRIPTION
What's changed, or what was fixed?

- Added region shorthands, in a backward compatible manner. for regions having long names as the provided/chosen region name forms the [bridge_name](https://github.com/apigee/terraform-modules/blob/83511f999117fec9f9106c70572360c2b595c65b/modules/apigee-x-bridge-mig/main.tf#L18) in the [apigee-x-bridge-mig](https://github.com/apigee/terraform-modules/tree/main/modules/apigee-x-bridge-mig) module and the upstream cloud-foundation-fabric/compute-vm module fails during service_account creation if the character count is more than 28 for the [account_id](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/b62fbe85565d92941e9b587197f0a7c947e9a6e8/modules/compute-vm/main.tf#L393) of service_account (uses the bridge_name to form account_id).
- Changes committed:
        - modified:   `modules/apigee-x-bridge-mig/main.tf`
- **Note:** To ensure backward compatibility, lookup map for only the regions which were contributing to more than 28 characters has been introduced, leaving rest of the regions and related names intact.

**Fixes:** #55 

- [] WIP: I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.