### PR TITLE
feat(psc-sb): add connection_state output for endpoint attachment

### DIFF
--- a/modules/sb-psc-attachment/README.md
+++ b/modules/sb-psc-attachment/README.md
@@ -32,4 +32,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_endpoint_attachment_host"></a> [endpoint\_attachment\_host](#output\_endpoint\_attachment\_host) | Host for the endpoint attachment to be used in Apigee. |
+| <a name="output_endpoint_attachment_connection_state"></a> [endpoint\_attachment\_connection_state](#output\_endpoint\_attachment\_connection_state) | Underlying connection state for the endpoint attachment. |
 <!-- END_TF_DOCS -->

--- a/modules/sb-psc-attachment/outputs.tf
+++ b/modules/sb-psc-attachment/outputs.tf
@@ -19,3 +19,7 @@ output "endpoint_attachment_host" {
   value       = google_apigee_endpoint_attachment.endpoint_attachment.host
 }
 
+output "endpoint_attachment_connection_state" {
+  description = "Underlying connection state for the endpoint attachment."
+  value       = google_apigee_endpoint_attachment.endpoint_attachment.connection_state
+}

--- a/samples/x-sb-psc/README.md
+++ b/samples/x-sb-psc/README.md
@@ -15,6 +15,7 @@ use for your target server in Apigee:
 Outputs:
 
 psc_endpoint_attachment_host = "7.0.5.2"
+psc_endpoint_attachment_connection_state = "ACCEPTED"
 ```
 
 <!-- BEGIN_TF_DOCS -->
@@ -69,4 +70,5 @@ psc_endpoint_attachment_host = "7.0.5.2"
 | Name | Description |
 |------|-------------|
 | <a name="output_psc_endpoint_attachment_host"></a> [psc\_endpoint\_attachment\_host](#output\_psc\_endpoint\_attachment\_host) | Hostname of the PSC endpoint attachment. |
+| <a name="output_psc_endpoint_attachment_connection_state"></a> [psc\_endpoint\_attachment\_connection_state](#output\_psc\_endpoint\_attachment\_connection_state) | Underlying connection state of the PSC endpoint attachment. |
 <!-- END_TF_DOCS -->

--- a/samples/x-sb-psc/outputs.tf
+++ b/samples/x-sb-psc/outputs.tf
@@ -18,3 +18,8 @@ output "psc_endpoint_attachment_host" {
   description = "Hostname of the PSC endpoint attachment."
   value       = module.southbound-psc.endpoint_attachment_host
 }
+
+output "psc_endpoint_attachment_connection_state" {
+  description = "Underlying connection state of the PSC endpoint attachment."
+  value       = module.southbound-psc.endpoint_attachment_connection_state
+}


### PR DESCRIPTION
What's changed, or what was fixed?

- added the endpoint attachment's connection state as an output for the `southbound-psc` module, supported in the [v4.37.0](https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.37.0) release of the Google Terraform provider 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.