### PR TITLE
feat: added labels to global_forwarding_rule

### DIFF
--- a/modules/l4xlb/README.md
+++ b/modules/l4xlb/README.md
@@ -26,6 +26,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_backend_migs"></a> [backend\_migs](#input\_backend\_migs) | List of MIGs to be used as backends. | `list(string)` | n/a | yes |
 | <a name="input_external_ip"></a> [external\_ip](#input\_external\_ip) | External IP for the L7 XLB. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of label key:value pairs to assign to the forwarding rule.<br>Default is an empty map. | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | External LB name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id. | `string` | n/a | yes |
 

--- a/modules/l4xlb/main.tf
+++ b/modules/l4xlb/main.tf
@@ -46,6 +46,7 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   target     = google_compute_target_tcp_proxy.proxy.id
   ip_address = var.external_ip != null ? var.external_ip : null
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_target_tcp_proxy" "proxy" {

--- a/modules/l4xlb/variables.tf
+++ b/modules/l4xlb/variables.tf
@@ -38,8 +38,8 @@ variable "name" {
 variable "labels" {
   type        = map(string)
   default     = {}
-  description = <<EOD
-An optional map of label key:value pairs to assign to the forwarding rule.
-Default is an empty map.
-EOD
+  description = <<-EOD
+  An optional map of label key:value pairs to assign to the forwarding rule.
+  Default is an empty map.
+  EOD
 }

--- a/modules/l4xlb/variables.tf
+++ b/modules/l4xlb/variables.tf
@@ -34,3 +34,12 @@ variable "name" {
   description = "External LB name."
   type        = string
 }
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = <<EOD
+An optional map of label key:value pairs to assign to the forwarding rule.
+Default is an empty map.
+EOD
+}

--- a/modules/mig-l7xlb/README.md
+++ b/modules/mig-l7xlb/README.md
@@ -27,6 +27,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_backend_migs"></a> [backend\_migs](#input\_backend\_migs) | List of MIGs to be used as backends. | `list(string)` | n/a | yes |
 | <a name="input_external_ip"></a> [external\_ip](#input\_external\_ip) | (Optional) External IP for the L7 XLB. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of label key:value pairs to assign to the forwarding rule.<br>Default is an empty map. | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | External LB name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id. | `string` | n/a | yes |
 | <a name="input_security_policy"></a> [security\_policy](#input\_security\_policy) | (Optional) The security policy associated with this backend service. | `string` | `null` | no |

--- a/modules/mig-l7xlb/main.tf
+++ b/modules/mig-l7xlb/main.tf
@@ -58,4 +58,5 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   target     = google_compute_target_https_proxy.https_proxy.id
   ip_address = var.external_ip != null ? var.external_ip : null
   port_range = "443"
+  labels     = var.labels
 }

--- a/modules/mig-l7xlb/variables.tf
+++ b/modules/mig-l7xlb/variables.tf
@@ -45,3 +45,12 @@ variable "security_policy" {
   type        = string
   default     = null
 }
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = <<EOD
+An optional map of label key:value pairs to assign to the forwarding rule.
+Default is an empty map.
+EOD
+}

--- a/modules/mig-l7xlb/variables.tf
+++ b/modules/mig-l7xlb/variables.tf
@@ -49,8 +49,8 @@ variable "security_policy" {
 variable "labels" {
   type        = map(string)
   default     = {}
-  description = <<EOD
-An optional map of label key:value pairs to assign to the forwarding rule.
-Default is an empty map.
-EOD
+  description = <<-EOD
+  An optional map of label key:value pairs to assign to the forwarding rule.
+  Default is an empty map.
+  EOD
 }

--- a/modules/nb-psc-l7xlb/README.md
+++ b/modules/nb-psc-l7xlb/README.md
@@ -23,6 +23,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_external_ip"></a> [external\_ip](#input\_external\_ip) | External IP for the L7 XLB. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of label key:value pairs to assign to the forwarding rule.<br>Default is an empty map. | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | External LB name. | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Network for the PSC NEG | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id. | `string` | n/a | yes |

--- a/modules/nb-psc-l7xlb/main.tf
+++ b/modules/nb-psc-l7xlb/main.tf
@@ -52,5 +52,6 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   ip_address            = var.external_ip != null ? var.external_ip : null
   port_range            = "443"
   load_balancing_scheme = "EXTERNAL_MANAGED"
+  labels                = var.labels
 }
 

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -60,8 +60,8 @@ variable "psc_negs" {
 variable "labels" {
   type        = map(string)
   default     = {}
-  description = <<EOD
-An optional map of label key:value pairs to assign to the forwarding rule.
-Default is an empty map.
-EOD
+  description = <<-EOD
+  An optional map of label key:value pairs to assign to the forwarding rule.
+  Default is an empty map.
+  EOD
 }

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -56,3 +56,12 @@ variable "psc_negs" {
   description = "List of PSC NEGs to be used as backends."
   type        = list(string)
 }
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = <<EOD
+An optional map of label key:value pairs to assign to the forwarding rule.
+Default is an empty map.
+EOD
+}

--- a/samples/hybrid-gke/hybrid-demo.tfvars
+++ b/samples/hybrid-gke/hybrid-demo.tfvars
@@ -26,19 +26,19 @@ apigee_envgroups = {
 }
 
 subnets = [{
-  name               = "hybrid-europe-west1"
-  ip_cidr_range      = "10.0.0.0/24"
-  region             = "europe-west1"
+  name          = "hybrid-europe-west1"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "europe-west1"
   secondary_ip_range = {
-    pods = "10.100.0.0/20"
+    pods     = "10.100.0.0/20"
     services = "10.101.0.0/23"
   }
 }]
 
 cluster_location = "europe-west1"
-cluster_region = "europe-west1"
+cluster_region   = "europe-west1"
 
 # POC settings to reduce infrastructure cost
 # reconsider using these for production!
 node_preemptible_runtime = true
-node_locations_data = ["europe-west1-b"]
+node_locations_data      = ["europe-west1-b"]

--- a/samples/x-controlled-internet-egress/x-demo.tfvars
+++ b/samples/x-controlled-internet-egress/x-demo.tfvars
@@ -40,8 +40,8 @@ support_range = "10.1.0.0/28"
 
 firewall_appliance_zone = "europe-west1-c"
 firewall_appliance_subnet = {
-  name = "egress"
-  region = "europe-west1"
-  ip_cidr_range = "10.100.0.0/28"
+  name               = "egress"
+  region             = "europe-west1"
+  ip_cidr_range      = "10.100.0.0/28"
   secondary_ip_range = null
 }

--- a/samples/x-shared-vpc/x-demo.tfvars
+++ b/samples/x-shared-vpc/x-demo.tfvars
@@ -44,5 +44,5 @@ exposure_subnets = [
   }
 ]
 
-peering_range  = "10.0.0.0/22"
-support_range  = "10.1.0.0/28"
+peering_range = "10.0.0.0/22"
+support_range = "10.1.0.0/28"


### PR DESCRIPTION
What's changed, or what was fixed?

added labels argument and variable to all global_forwarding_rule resources

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.