### PR TITLE
build: update terraform version for tftest to v1.3.4

### DIFF
--- a/.github/actions/tftest/Dockerfile
+++ b/.github/actions/tftest/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3-alpine
 RUN apk add --no-cache \
     git
 
-ENV TERRAFORM_VERSION=1.1.7
+ENV TERRAFORM_VERSION=1.3.4
 
 RUN wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \


### PR DESCRIPTION
What's changed, or what was fixed?

- Updated Terraform Version to v1.3.4 for tftest in order to enable `optional` type.

**Fixes:** #issue

- [X] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.