### PR TITLE
Updated apigee_envgroups variable type in hybrid-gke sample to match with referenced apigee module

### DIFF
--- a/samples/hybrid-gke/hybrid-demo.tfvars
+++ b/samples/hybrid-gke/hybrid-demo.tfvars
@@ -34,9 +34,7 @@ apigee_environments = {
 }
 
 apigee_envgroups = {
-  test = {
-    hostnames = ["test.api.example.com"]
-  }
+  test = ["test.api.example.com"]
 }
 
 subnets = [{

--- a/samples/hybrid-gke/outputs.tf
+++ b/samples/hybrid-gke/outputs.tf
@@ -26,5 +26,5 @@ output "cluster_region" {
 
 output "apigee_envgroups" {
   description = "Apigee Env Groups."
-  value       = local.env_groups
+  value       = module.apigee.envgroups
 }

--- a/samples/hybrid-gke/variables.tf
+++ b/samples/hybrid-gke/variables.tf
@@ -26,9 +26,7 @@ variable "ax_region" {
 
 variable "apigee_envgroups" {
   description = "Apigee Environment Groups."
-  type = map(object({
-    hostnames = list(string)
-  }))
+  type = map(list(string))
   default = {}
 }
 


### PR DESCRIPTION
Updated apigee_envgroups variable type in hybrid-gke sample to match with referenced apigee module

chore(main): release 0.13.0

What's changed, or what was fixed?

- Updated apigee_envgroups variable type in samples/hybrid-gke/variables.tf to match with apigee module: github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v19.0.0.
- Updated sample value accordingly in samples/hybrid-gke/hybrid-demo.tfvars.
- Updated output variable apigee_envgroups in samples/hybrid-gke/outputs.tf to remove local reference.

**Fixes:** #issue

- [ x ] I have run all the tests locally and they all pass.
- [ x ] I have followed the relevant style guide for my changes.