### PR TITLE
feat: adding logs and timeout and ssl policy parameters to external load balancer

### DIFF
--- a/modules/mig-l7xlb/main.tf
+++ b/modules/mig-l7xlb/main.tf
@@ -28,7 +28,7 @@ resource "google_compute_backend_service" "mig_backend" {
   name            = "${var.name}-backend"
   port_name       = "https"
   protocol        = "HTTPS"
-  timeout_sec     = 10
+  timeout_sec     = var.backend_timeout
   health_checks   = [google_compute_health_check.mig_lb_hc.id]
   security_policy = var.security_policy
   dynamic "backend" {
@@ -36,6 +36,10 @@ resource "google_compute_backend_service" "mig_backend" {
     content {
       group = backend.value
     }
+  }
+  log_config {
+    enable      = var.logs_enabled
+    sample_rate = var.logs_sample_rate
   }
 }
 

--- a/modules/mig-l7xlb/main.tf
+++ b/modules/mig-l7xlb/main.tf
@@ -54,6 +54,7 @@ resource "google_compute_target_https_proxy" "https_proxy" {
   name             = "${var.name}-target-proxy"
   url_map          = google_compute_url_map.url_map.id
   ssl_certificates = [var.ssl_certificate]
+  ssl_policy       = var.ssl_policy
 }
 
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {

--- a/modules/mig-l7xlb/variables.tf
+++ b/modules/mig-l7xlb/variables.tf
@@ -75,3 +75,12 @@ variable "labels" {
   Default is an empty map.
   EOD
 }
+
+variable "ssl_policy" {
+  type        = string
+  default     = null
+  description = <<-EOD
+  A reference to the SslPolicy resource that will be associated with the TargetHttpsProxy resource. 
+  If not set, the TargetHttpsProxy resource will not have any SSL policy configured.
+  EOD
+}

--- a/modules/mig-l7xlb/variables.tf
+++ b/modules/mig-l7xlb/variables.tf
@@ -46,6 +46,27 @@ variable "security_policy" {
   default     = null
 }
 
+variable "logs_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable logging for the load balancer traffic served by this backend service."
+}
+
+variable "backend_timeout" {
+  type        = number
+  default     = 10
+  description = "Backend timeout in seconds"
+}
+
+variable "logs_sample_rate" {
+  default     = null
+  type        = number
+  description = <<-EOD
+  This field can only be specified if logging is enabled for this backend service. 
+  The value of the field must be in [0, 1]. 
+  EOD
+}
+
 variable "labels" {
   type        = map(string)
   default     = {}

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -19,12 +19,6 @@ variable "project_id" {
   type        = string
 }
 
-variable "psc_service_attachments" {
-  description = "Map of region to service attachment ID (currently only one map entry is allowed)."
-  type        = map(string)
-  default     = {}
-}
-
 variable "ssl_certificate" {
   description = "SSL certificate for the HTTPS LB."
   type        = string
@@ -38,11 +32,6 @@ variable "external_ip" {
 
 variable "name" {
   description = "External LB name."
-  type        = string
-}
-
-variable "network" {
-  description = "Network for the PSC NEG"
   type        = string
 }
 


### PR DESCRIPTION
What's changed, or what was fixed?

- added log configuration for the mig-l7xlb module
- added timeout configuration for mig-l7xlb
- added ssl policy configuration for mig-l7xlb

**Fixes:* #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.