### PR TITLE
fix: Fixed forwarding of client certificate in case of MTLS

### DIFF
--- a/modules/apigee-x-mtls-mig/envoy-config-template.yaml
+++ b/modules/apigee-x-mtls-mig/envoy-config-template.yaml
@@ -33,6 +33,10 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 route_config:
                   name: local_route
+                  request_headers_to_add:
+                  - header:
+                      key: "x-raw-client-cert"
+                      value: "%DOWNSTREAM_PEER_CERT%"
                   virtual_hosts:
                     - name: local_service
                       domains: ["*"]

--- a/samples/hybrid-gke/README.md
+++ b/samples/hybrid-gke/README.md
@@ -17,8 +17,9 @@ CLUSTER_REGION="$(terraform output -raw cluster_region)"
 CLUSTER_NAME="$(terraform output -raw cluster_name)"
 ENV_GROUPS=$(terraform output -json apigee_envgroups)
 ENV_GROUP_NAME=$(echo $ENV_GROUPS | jq -r "to_entries[0].key")
-ENV_NAME=$(echo $ENV_GROUPS | jq -r "to_entries[0].value.environments[0]")
 INGRESS_DOMAIN=$(echo $ENV_GROUPS | jq -r "to_entries[0].value.hostnames[0]")
+ENVS=$(terraform output -json apigee_environments)
+ENV_NAME=$(echo $ENVS | jq -r "to_entries[0].key")
 ```
 
 ### Log into the cluster
@@ -208,7 +209,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apigee_envgroups"></a> [apigee\_envgroups](#input\_apigee\_envgroups) | Apigee Environment Groups. | <pre>map(object({<br>    hostnames = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_apigee_envgroups"></a> [apigee\_envgroups](#input\_apigee\_envgroups) | Apigee Environment Groups. | `map(list(string))` | `{}` | no |
 | <a name="input_apigee_environments"></a> [apigee\_environments](#input\_apigee\_environments) | Apigee Environments. | <pre>map(object({<br>    display_name = optional(string)<br>    description  = optional(string)<br>    iam          = optional(map(list(string)))<br>    envgroups    = list(string)<br>  }))</pre> | `null` | no |
 | <a name="input_ax_region"></a> [ax\_region](#input\_ax\_region) | GCP region for storing Apigee analytics data (see https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli). | `string` | n/a | yes |
 | <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | Billing account id. | `string` | `null` | no |
@@ -231,10 +232,11 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_apigee_envgroups"></a> [apigee\_envgroups](#output\_apigee\_envgroups) | Apigee Env Groups. |
+| <a name="output_apigee_environments"></a> [apigee\_environments](#output\_apigee\_environments) | Apigee Environments |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Cluster name. |
 | <a name="output_cluster_region"></a> [cluster\_region](#output\_cluster\_region) | Cluster location. |
+<!-- END_TF_DOCS -->
 
 ## Copyright
 
 Copyright 2023 Google LLC. This software is provided as-is, without warranty or representation for any use or purpose. Your use of it is subject to your agreement with Google.
-<!-- END_TF_DOCS -->

--- a/samples/hybrid-gke/hybrid-demo.tfvars
+++ b/samples/hybrid-gke/hybrid-demo.tfvars
@@ -34,9 +34,7 @@ apigee_environments = {
 }
 
 apigee_envgroups = {
-  test = {
-    hostnames = ["test.api.example.com"]
-  }
+  test = ["test.api.example.com"]
 }
 
 subnets = [{

--- a/samples/hybrid-gke/main.tf
+++ b/samples/hybrid-gke/main.tf
@@ -52,7 +52,7 @@ module "vpc" {
 
 module "apigee" {
   source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v19.0.0"
-  project_id = var.project_id
+  project_id = module.project.project_id
   organization = {
     runtime_type     = "HYBRID"
     analytics_region = var.ax_region

--- a/samples/hybrid-gke/outputs.tf
+++ b/samples/hybrid-gke/outputs.tf
@@ -26,5 +26,10 @@ output "cluster_region" {
 
 output "apigee_envgroups" {
   description = "Apigee Env Groups."
-  value       = local.env_groups
+  value       = module.apigee.envgroups
+}
+
+output "apigee_environments" {
+  description = "Apigee Environments"
+  value       = module.apigee.environments
 }

--- a/samples/hybrid-gke/variables.tf
+++ b/samples/hybrid-gke/variables.tf
@@ -26,10 +26,8 @@ variable "ax_region" {
 
 variable "apigee_envgroups" {
   description = "Apigee Environment Groups."
-  type = map(object({
-    hostnames = list(string)
-  }))
-  default = {}
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "apigee_environments" {


### PR DESCRIPTION
What's changed, or what was fixed?

- Fixed forwarding of client certificate in case of MTLS: In the existing implementation, envoy was populating [x-forwarded-client-cert](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#id19) header. But this header was being discarded by Apigee. So, assigned the value of `%DOWNSTREAM_PEER_CERT%` command operator to a custom header named `x-raw-client-cert` in the envoy config.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.