### PR TITLE
fix: fixed forwarding of client certificate in case of mTLS

### DIFF
--- a/modules/apigee-x-mtls-mig/envoy-config-template.yaml
+++ b/modules/apigee-x-mtls-mig/envoy-config-template.yaml
@@ -33,6 +33,10 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 route_config:
                   name: local_route
+                  request_headers_to_add:
+                  - header:
+                      key: "x-raw-client-cert"
+                      value: "%DOWNSTREAM_PEER_CERT%"
                   virtual_hosts:
                     - name: local_service
                       domains: ["*"]


### PR DESCRIPTION
What's changed, or what was fixed?

Fixed forwarding of client certificate in case of mTLS: Envoy can populate [x-forwarded-client-cert](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert) header. But this header was being discarded by Apigee. So, assigned the value of `%DOWNSTREAM_PEER_CERT%` command operator to a custom header named `x-raw-client-cert` in the envoy config.

- [X] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.