### PR TITLE
fix: issue #115

### DIFF
--- a/samples/hybrid-gke/main.tf
+++ b/samples/hybrid-gke/main.tf
@@ -209,7 +209,7 @@ module "apigee-service-account" {
     ]
   }
   iam_project_roles = {
-    "module.project.project_id" = [
+    "${module.project.project_id}" = [
       "roles/logging.logWriter",
       "roles/monitoring.metricWriter",
       "roles/storage.objectAdmin",


### PR DESCRIPTION
What's changed, or what was fixed?

The key of the iam_project_roles in the Apigee Hybrid service accounts should be a reference to the output of a module.

**Fixes:** #115

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.