### PR TITLE
Demo Backend to return hostname instead of static string

### DIFF
--- a/modules/development-backend/main.tf
+++ b/modules/development-backend/main.tf
@@ -35,7 +35,7 @@ module "demo-backend-template" {
   }
   create_template = true
   metadata = {
-    startup-script = "sudo mkdir -p /var/www && cd /var/www && echo 'hello from demo' > index.html && python3 -m http.server 80"
+    startup-script = "sudo mkdir -p /var/www && cd /var/www && echo \"hello from $(hostname)\" > index.html && python3 -m http.server 80"
   }
   service_account_create = true
   service_account_scopes = ["cloud-platform"]


### PR DESCRIPTION
What's changed, or what was fixed?

- Updated demo backend index.html to return hostname in lieu of static string ("hello from my-host-123" instead of "hello from demo"
- This is to support showcasing the load balancing / failover in demos to see which backend host responded to the request.

- [ x ] I have run all the tests locally and they all pass.
- [ x ] I have followed the relevant style guide for my changes.