### PR TITLE
Outputs region for demo backend ILB

### DIFF
--- a/modules/development-backend/outputs.tf
+++ b/modules/development-backend/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,9 @@ output "ilb_forwarding_rule_address" {
 output "ilb_forwarding_rule_self_link" {
   description = "ILB forwarding rule self link."
   value       = module.ilb-backend.forwarding_rule_self_link
+}
+
+output "region" {
+  description = "Backend Service region."
+  value       = module.ilb-backend.forwarding_rule.region
 }


### PR DESCRIPTION
What's changed, or what was fixed?

- Added demo backend ILB region value to outputs so it can be used downstream when setting up demos (ie for loop across backends and utilise their region value)

- [ x ] I have run all the tests locally and they all pass.
- [ x ] I have followed the relevant style guide for my changes.