### PR TITLE
Fix Org ID param formatting for x-sb-psc sample

### DIFF
--- a/samples/x-sb-psc/main.tf
+++ b/samples/x-sb-psc/main.tf
@@ -84,7 +84,7 @@ module "southbound-psc" {
   project_id          = module.project.project_id
   name                = var.psc_name
   region              = var.backend_region
-  apigee_organization = module.apigee-x-core.org_id
+  apigee_organization = module.project.project_id
   nat_subnets         = [google_compute_subnetwork.psc_nat_subnet.id]
   target_service      = module.backend-example.ilb_forwarding_rule_self_link
   depends_on = [


### PR DESCRIPTION
What's changed, or what was fixed?

- Updated Org ID format
- If used as is the Org ID param will result into "organizations/organizations/my-org-id" since the resource "google_apigee_endpoint_attachment" "endpoint_attachment" in sb-psc-attachment module already concatenates the Org ID string to "organizations/${var.apigee_organization}"
- Passing the Project ID only (which is identical with the Org ID) is sufficient.

- [ x ] I have run all the tests locally and they all pass.
- [ x ] I have followed the relevant style guide for my changes.