### PR TITLE
feat: bumped cff module version for apigee & kms to v26.0.0

### DIFF
--- a/.github/actions/tftest/Dockerfile
+++ b/.github/actions/tftest/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3-alpine
 RUN apk add --no-cache \
     git
 
-ENV TERRAFORM_VERSION=1.3.4
+ENV TERRAFORM_VERSION=1.4.4
 
 RUN wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \

--- a/modules/apigee-x-core/README.md
+++ b/modules/apigee-x-core/README.md
@@ -1,6 +1,5 @@
 # Apigee Core Setup
 
-<!-- BEGIN_TF_DOCS -->
 ## Providers
 
 | Name | Version |
@@ -11,9 +10,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apigee"></a> [apigee](#module\_apigee) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee | v19.0.0 |
-| <a name="module_kms-inst-disk"></a> [kms-inst-disk](#module\_kms-inst-disk) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v19.0.0 |
-| <a name="module_kms-org-db"></a> [kms-org-db](#module\_kms-org-db) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v19.0.0 |
+| <a name="module_apigee"></a> [apigee](#module\_apigee) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee | v26.0.0 |
+| <a name="module_kms-inst-disk"></a> [kms-inst-disk](#module\_kms-inst-disk) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v26.0.0 |
+| <a name="module_kms-org-db"></a> [kms-org-db](#module\_kms-org-db) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v26.0.0 |
 
 ## Resources
 
@@ -27,7 +26,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_apigee_envgroups"></a> [apigee\_envgroups](#input\_apigee\_envgroups) | Apigee Environment Groups. | <pre>map(object({<br>    hostnames = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_apigee_environments"></a> [apigee\_environments](#input\_apigee\_environments) | Apigee Environments. | <pre>map(object({<br>    display_name = optional(string)<br>    description  = optional(string, "Terraform-managed")<br>    node_config = optional(object({<br>      min_node_count = optional(number)<br>      max_node_count = optional(number)<br>    }))<br>    iam       = optional(map(list(string)))<br>    envgroups = list(string)<br>  }))</pre> | `null` | no |
-| <a name="input_apigee_instances"></a> [apigee\_instances](#input\_apigee\_instances) | Apigee Instances (only one instance for EVAL). | <pre>map(object({<br>    region              = string<br>    ip_range            = string<br>    environments        = list(string)<br>    keyring_create      = optional(bool, true)<br>    keyring_name        = optional(string, null)<br>    keyring_location    = optional(string, null)<br>    key_name            = optional(string, "inst-disk")<br>    key_rotation_period = optional(string, "2592000s")<br>    key_labels          = optional(map(string), null)<br>    consumer_accept_list          = optional(list(string), null)<br>  }))</pre> | `{}` | no |
+| <a name="input_apigee_instances"></a> [apigee\_instances](#input\_apigee\_instances) | Apigee Instances (only one instance for EVAL). | <pre>map(object({<br>    region               = string<br>    ip_range             = string<br>    environments         = list(string)<br>    keyring_create       = optional(bool, true)<br>    keyring_name         = optional(string, null)<br>    keyring_location     = optional(string, null)<br>    key_name             = optional(string, "inst-disk")<br>    key_rotation_period  = optional(string, "2592000s")<br>    key_labels           = optional(map(string), null)<br>    consumer_accept_list = optional(list(string), null)<br>  }))</pre> | `{}` | no |
 | <a name="input_ax_region"></a> [ax\_region](#input\_ax\_region) | GCP region for storing Apigee analytics data (see https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli). | `string` | n/a | yes |
 | <a name="input_billing_type"></a> [billing\_type](#input\_billing\_type) | Billing type of the Apigee organization. | `string` | `null` | no |
 | <a name="input_network"></a> [network](#input\_network) | Network (self-link) to peer with the Apigee tennant project. | `string` | n/a | yes |
@@ -50,4 +49,3 @@
 | <a name="output_instance_service_attachments"></a> [instance\_service\_attachments](#output\_instance\_service\_attachments) | Map of instance region -> instance PSC service attachment |
 | <a name="output_org_id"></a> [org\_id](#output\_org\_id) | Apigee Organization ID in the format of 'organizations/<org\_id>' |
 | <a name="output_organization"></a> [organization](#output\_organization) | Apigee Organization. |
-<!-- END_TF_DOCS -->

--- a/modules/apigee-x-core/main.tf
+++ b/modules/apigee-x-core/main.tf
@@ -32,7 +32,7 @@ resource "google_project_service_identity" "apigee_sa" {
 }
 
 module "kms-org-db" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v19.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v26.0.0"
   project_id = var.project_id
   key_iam = {
     org-db = {
@@ -51,7 +51,7 @@ module "kms-org-db" {
 
 module "kms-inst-disk" {
   for_each   = var.apigee_instances
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v19.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v26.0.0"
   project_id = var.project_id
   key_iam = {
     (each.value.key_name) = {
@@ -72,7 +72,7 @@ module "kms-inst-disk" {
 }
 
 module "apigee" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v19.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v26.0.0"
   project_id = var.project_id
   organization = {
     display_name            = var.org_display_name

--- a/modules/apigee-x-core/versions.tf
+++ b/modules/apigee-x-core/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.4.4"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/tests/samples/test_controlled_internet_egress.py
+++ b/tests/samples/test_controlled_internet_egress.py
@@ -44,7 +44,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_dns_peering.py
+++ b/tests/samples/test_dns_peering.py
@@ -16,7 +16,7 @@
 import os
 import pytest
 from .utils import *
-
+import json
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "../../samples/x-dns-peering")
 
 
@@ -28,6 +28,7 @@ def resources(recursive_plan_runner):
         project_id="testonly",
         project_create="true"
     )
+    print(json.dumps(resources,indent=2))
     return resources
 
 
@@ -43,7 +44,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_ilb_mtls.py
+++ b/tests/samples/test_ilb_mtls.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_l4xlb_mtls.py
+++ b/tests/samples/test_l4xlb_mtls.py
@@ -43,8 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
-
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 def test_envgroup_attachment(resources):
     "Test Apigee Envgroup Attachments."

--- a/tests/samples/test_l7xlb.py
+++ b/tests/samples/test_l7xlb.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_multi_region.py
+++ b/tests/samples/test_multi_region.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_nb_psc_xlb.py
+++ b/tests/samples/test_nb_psc_xlb.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_sb_psc.py
+++ b/tests/samples/test_sb_psc.py
@@ -44,7 +44,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_shared_vpc.py
+++ b/tests/samples/test_shared_vpc.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_transtive_peering.py
+++ b/tests/samples/test_transtive_peering.py
@@ -45,7 +45,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_x_basic.py
+++ b/tests/samples/test_x_basic.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["euw1-instance-test1", "euw1-instance-test2"])
+    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
 
 
 def test_envgroup_attachment(resources):


### PR DESCRIPTION
What's changed, or what was fixed?

- Bumped Cloud Foundation Fabric  module version for Apigee to  v26.0.0
- Bumped Cloud Foundation Fabric module version for  KMS to v26.0.0

**Fixes:** #issue

- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.