### PR TITLE
Fix output of apigee-x-core and apigee invocation

### DIFF
--- a/modules/apigee-x-core/main.tf
+++ b/modules/apigee-x-core/main.tf
@@ -17,6 +17,7 @@
 locals {
   envgroups = { for key, value in var.apigee_envgroups : key => value.hostnames }
   instances = { for key, value in var.apigee_instances : value.region => {
+    name                  = key
     environments          = value.environments
     runtime_ip_cidr_range = value.ip_range
     disk_encryption_key   = module.kms-inst-disk[key].key_ids[value.key_name]

--- a/modules/apigee-x-core/outputs.tf
+++ b/modules/apigee-x-core/outputs.tf
@@ -17,7 +17,7 @@
 output "instance_endpoints" {
   description = "Map of instance name -> internal runtime endpoint IP address"
   value = tomap({
-    for name, instance in module.apigee.instances : name => instance.host
+    for name, instance in module.apigee.instances : instance.name => instance.host
   })
 }
 


### PR DESCRIPTION
**What's changed, or what was fixed?**

- output `apigee-x-core.instance_endpoints` is supposed to be a map of `instance name => instance endpoint IP`, which is not the case. When printed, the output turns out to map `region => instance endpoint IP`. Changed this to properly reflect the instances actual name.
- in `apigee-x-core`'s `locals` is a definition for `local.instances`, which doesn't pass the key (desired instance name) from the instance-map set as variable into `local.instances`. This local variable is then passed to module `apigee`, which falls back to a default-name, due to the lack of a `name` field. This causes a de-sync between the expected instance name and the actual instance name.

My environment successfully built up after applying the changes, as looking up the expected instance name in the `apigee-x-core.instance_enpoints` map no longer causes Terraform's `each.key doesn't reference an object in this map` error.
Printing the output values confirms, that they are now according to documentation ([output description](https://github.com/apigee/terraform-modules/blob/main/modules/apigee-x-core/outputs.tf#L17) and [README.md documentation](https://github.com/apigee/terraform-modules/tree/main/modules/apigee-x-core#output_instance_endpoints)).

**Fixes:** #137 

- [x] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.