### PR TITLE
Bump CFF dependencies to v28.0.0 (latest)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ modules/apigee-hybrid-workload/overrides/
 **.key
 modules/apigee-hybrid-workload/apigeectl_*
 __pycache__
+.venv

--- a/modules/apigee-x-bridge-mig/README.md
+++ b/modules/apigee-x-bridge-mig/README.md
@@ -11,8 +11,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bridge-mig"></a> [bridge-mig](#module\_bridge-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v16.0.0 |
-| <a name="module_bridge-template"></a> [bridge-template](#module\_bridge-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v16.0.0 |
+| <a name="module_bridge-mig"></a> [bridge-mig](#module\_bridge-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
+| <a name="module_bridge-template"></a> [bridge-template](#module\_bridge-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
 
 ## Resources
 

--- a/modules/apigee-x-bridge-mig/README.md
+++ b/modules/apigee-x-bridge-mig/README.md
@@ -11,8 +11,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bridge-mig"></a> [bridge-mig](#module\_bridge-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
-| <a name="module_bridge-template"></a> [bridge-template](#module\_bridge-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
+| <a name="module_bridge-mig"></a> [bridge-mig](#module\_bridge-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v28.0.0 |
+| <a name="module_bridge-template"></a> [bridge-template](#module\_bridge-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v28.0.0 |
 
 ## Resources
 

--- a/modules/apigee-x-bridge-mig/main.tf
+++ b/modules/apigee-x-bridge-mig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "bridge-template" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v16.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
   project_id    = var.project_id
   name          = local.bridge_name
   zone          = "${var.region}-b"
@@ -33,9 +33,11 @@ module "bridge-template" {
     alias_ips  = null
   }]
   boot_disk = {
-    image = "debian-cloud/debian-11"
-    type  = "pd-standard"
-    size  = 20
+    initialize_params = {
+      image = "debian-cloud/debian-11"
+      type  = "pd-standard"
+      size  = 20
+    }
   }
   create_template = true
   metadata = {
@@ -47,17 +49,13 @@ module "bridge-template" {
 }
 
 module "bridge-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v16.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
   project_id        = var.project_id
   location          = var.region
-  regional          = true
   name              = local.bridge_name
   target_size       = var.target_size
   autoscaler_config = var.autoscaler_config
-  default_version = {
-    instance_template = module.bridge-template.template.self_link
-    name              = "default"
-  }
+  instance_template = module.bridge-template.template.self_link
   named_ports = {
     https = 443
   }
@@ -66,13 +64,10 @@ module "bridge-mig" {
     initial_delay_sec = 30
   }
   health_check_config = {
-    type = "https"
-    check = {
+    https = {
       port         = 443,
       request_path = "/healthz/ingress"
     }
-    config  = {}
-    logging = false
   }
 }
 

--- a/modules/apigee-x-bridge-mig/main.tf
+++ b/modules/apigee-x-bridge-mig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "bridge-template" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v28.0.0"
   project_id    = var.project_id
   name          = local.bridge_name
   zone          = "${var.region}-b"
@@ -44,12 +44,14 @@ module "bridge-template" {
     ENDPOINT           = var.endpoint_ip
     startup-script-url = "gs://apigee-5g-saas/apigee-envoy-proxy-release/latest/conf/startup-script.sh"
   }
-  service_account_create = true
-  service_account_scopes = ["cloud-platform"]
+  service_account = {
+    auto_create = true
+    scopes      = ["cloud-platform"]
+  }
 }
 
 module "bridge-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v28.0.0"
   project_id        = var.project_id
   location          = var.region
   name              = local.bridge_name

--- a/modules/apigee-x-core/README.md
+++ b/modules/apigee-x-core/README.md
@@ -61,9 +61,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apigee"></a> [apigee](#module\_apigee) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee | v26.0.0 |
-| <a name="module_kms-inst-disk"></a> [kms-inst-disk](#module\_kms-inst-disk) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v26.0.0 |
-| <a name="module_kms-org-db"></a> [kms-org-db](#module\_kms-org-db) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v26.0.0 |
+| <a name="module_apigee"></a> [apigee](#module\_apigee) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee | v28.0.0 |
+| <a name="module_kms-inst-disk"></a> [kms-inst-disk](#module\_kms-inst-disk) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v28.0.0 |
+| <a name="module_kms-org-db"></a> [kms-org-db](#module\_kms-org-db) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms | v28.0.0 |
 
 ## Resources
 

--- a/modules/apigee-x-core/main.tf
+++ b/modules/apigee-x-core/main.tf
@@ -32,7 +32,7 @@ resource "google_project_service_identity" "apigee_sa" {
 }
 
 module "kms-org-db" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v28.0.0"
   project_id = var.project_id
   iam = {
     "roles/cloudkms.cryptoKeyEncrypterDecrypter" = ["serviceAccount:${google_project_service_identity.apigee_sa.email}"]
@@ -49,7 +49,7 @@ module "kms-org-db" {
 
 module "kms-inst-disk" {
   for_each   = var.apigee_instances
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v28.0.0"
   project_id = var.project_id
   iam = {
     "roles/cloudkms.cryptoKeyEncrypterDecrypter" = ["serviceAccount:${google_project_service_identity.apigee_sa.email}"]
@@ -68,7 +68,7 @@ module "kms-inst-disk" {
 }
 
 module "apigee" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/apigee?ref=v28.0.0"
   project_id = var.project_id
   organization = {
     display_name            = var.org_display_name

--- a/modules/apigee-x-mtls-mig/README.md
+++ b/modules/apigee-x-mtls-mig/README.md
@@ -27,11 +27,11 @@ route_config:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apigee-mtls-proxy-mig"></a> [apigee-mtls-proxy-mig](#module\_apigee-mtls-proxy-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
-| <a name="module_apigee-mtls-proxy-template"></a> [apigee-mtls-proxy-template](#module\_apigee-mtls-proxy-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
-| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
-| <a name="module_mtls-proxy-sa"></a> [mtls-proxy-sa](#module\_mtls-proxy-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v26.0.0 |
-| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v26.0.0 |
+| <a name="module_apigee-mtls-proxy-mig"></a> [apigee-mtls-proxy-mig](#module\_apigee-mtls-proxy-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v28.0.0 |
+| <a name="module_apigee-mtls-proxy-template"></a> [apigee-mtls-proxy-template](#module\_apigee-mtls-proxy-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v28.0.0 |
+| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v28.0.0 |
+| <a name="module_mtls-proxy-sa"></a> [mtls-proxy-sa](#module\_mtls-proxy-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v28.0.0 |
+| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v28.0.0 |
 
 ## Resources
 

--- a/modules/apigee-x-mtls-mig/README.md
+++ b/modules/apigee-x-mtls-mig/README.md
@@ -27,11 +27,11 @@ route_config:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apigee-mtls-proxy-mig"></a> [apigee-mtls-proxy-mig](#module\_apigee-mtls-proxy-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v16.0.0 |
-| <a name="module_apigee-mtls-proxy-template"></a> [apigee-mtls-proxy-template](#module\_apigee-mtls-proxy-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v16.0.0 |
-| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v16.0.0 |
-| <a name="module_mtls-proxy-sa"></a> [mtls-proxy-sa](#module\_mtls-proxy-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v16.0.0 |
-| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v16.0.0 |
+| <a name="module_apigee-mtls-proxy-mig"></a> [apigee-mtls-proxy-mig](#module\_apigee-mtls-proxy-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
+| <a name="module_apigee-mtls-proxy-template"></a> [apigee-mtls-proxy-template](#module\_apigee-mtls-proxy-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
+| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
+| <a name="module_mtls-proxy-sa"></a> [mtls-proxy-sa](#module\_mtls-proxy-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v26.0.0 |
+| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v26.0.0 |
 
 ## Resources
 

--- a/modules/apigee-x-mtls-mig/main.tf
+++ b/modules/apigee-x-mtls-mig/main.tf
@@ -19,13 +19,13 @@ resource "random_id" "bucket" {
 }
 
 module "mtls-proxy-sa" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v28.0.0"
   project_id = var.project_id
   name       = "apigee-mtls-proxy-vm"
 }
 
 module "config-bucket" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v28.0.0"
   project_id = var.project_id
   name       = "apigee-mtls-ingress-${random_id.bucket.dec}"
   location   = "EU"
@@ -65,7 +65,7 @@ resource "google_storage_bucket_object" "tls_key" {
 }
 
 module "apigee-mtls-proxy-template" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v28.0.0"
   project_id    = var.project_id
   name          = "apigee-nb-mtls-proxy"
   zone          = "${var.region}-b"
@@ -90,8 +90,10 @@ module "apigee-mtls-proxy-template" {
     BUCKET             = module.config-bucket.name
     startup-script-url = "gs://${module.config-bucket.name}/setup.sh"
   }
-  service_account        = module.mtls-proxy-sa.email
-  service_account_scopes = ["cloud-platform"]
+  service_account = {
+    scopes = ["cloud-platform"]
+    email  = module.mtls-proxy-sa.email
+  }
   depends_on = [
     google_storage_bucket_object.setup_script,
     google_storage_bucket_object.ca_cert,
@@ -103,7 +105,7 @@ module "apigee-mtls-proxy-template" {
 }
 
 module "apigee-mtls-proxy-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v28.0.0"
   project_id        = var.project_id
   location          = var.region
   name              = "apigee-mtls-proxy-${var.region}"
@@ -116,7 +118,7 @@ module "apigee-mtls-proxy-mig" {
 }
 
 module "nat" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v26.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v28.0.0"
   project_id     = var.project_id
   region         = var.region
   name           = "nat-${var.region}"

--- a/modules/apigee-x-mtls-mig/main.tf
+++ b/modules/apigee-x-mtls-mig/main.tf
@@ -19,13 +19,13 @@ resource "random_id" "bucket" {
 }
 
 module "mtls-proxy-sa" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v26.0.0"
   project_id = var.project_id
   name       = "apigee-mtls-proxy-vm"
 }
 
 module "config-bucket" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
   project_id = var.project_id
   name       = "apigee-mtls-ingress-${random_id.bucket.dec}"
   location   = "EU"
@@ -65,7 +65,7 @@ resource "google_storage_bucket_object" "tls_key" {
 }
 
 module "apigee-mtls-proxy-template" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v16.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
   project_id    = var.project_id
   name          = "apigee-nb-mtls-proxy"
   zone          = "${var.region}-b"
@@ -79,9 +79,11 @@ module "apigee-mtls-proxy-template" {
     alias_ips  = null
   }]
   boot_disk = {
-    image = "projects/debian-cloud/global/images/family/debian-11"
-    type  = "pd-standard"
-    size  = 10
+    initialize_params = {
+      image = "projects/debian-cloud/global/images/family/debian-11"
+      type  = "pd-standard"
+      size  = 10
+    }
   }
   create_template = true
   metadata = {
@@ -101,24 +103,20 @@ module "apigee-mtls-proxy-template" {
 }
 
 module "apigee-mtls-proxy-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v16.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
   project_id        = var.project_id
   location          = var.region
-  regional          = true
   name              = "apigee-mtls-proxy-${var.region}"
   target_size       = var.target_size
   autoscaler_config = var.autoscaler_config
   named_ports = {
     https = 443
   }
-  default_version = {
-    instance_template = module.apigee-mtls-proxy-template.template.self_link
-    name              = "default"
-  }
+  instance_template = module.apigee-mtls-proxy-template.template.self_link
 }
 
 module "nat" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v16.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v26.0.0"
   project_id     = var.project_id
   region         = var.region
   name           = "nat-${var.region}"

--- a/modules/development-backend/README.md
+++ b/modules/development-backend/README.md
@@ -9,9 +9,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_demo-backend-mig"></a> [demo-backend-mig](#module\_demo-backend-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
-| <a name="module_demo-backend-template"></a> [demo-backend-template](#module\_demo-backend-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
-| <a name="module_ilb-backend"></a> [ilb-backend](#module\_ilb-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
+| <a name="module_demo-backend-mig"></a> [demo-backend-mig](#module\_demo-backend-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v28.0.0 |
+| <a name="module_demo-backend-template"></a> [demo-backend-template](#module\_demo-backend-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v28.0.0 |
+| <a name="module_ilb-backend"></a> [ilb-backend](#module\_ilb-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v28.0.0 |
 
 ## Resources
 

--- a/modules/development-backend/README.md
+++ b/modules/development-backend/README.md
@@ -9,9 +9,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_demo-backend-mig"></a> [demo-backend-mig](#module\_demo-backend-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v16.0.0 |
-| <a name="module_demo-backend-template"></a> [demo-backend-template](#module\_demo-backend-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v16.0.0 |
-| <a name="module_ilb-backend"></a> [ilb-backend](#module\_ilb-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-ilb | v16.0.0 |
+| <a name="module_demo-backend-mig"></a> [demo-backend-mig](#module\_demo-backend-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
+| <a name="module_demo-backend-template"></a> [demo-backend-template](#module\_demo-backend-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
+| <a name="module_ilb-backend"></a> [ilb-backend](#module\_ilb-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
 
 ## Resources
 

--- a/modules/development-backend/main.tf
+++ b/modules/development-backend/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "demo-backend-template" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v28.0.0"
   project_id    = var.project_id
   name          = var.name
   zone          = "${var.region}-b"
@@ -39,12 +39,14 @@ module "demo-backend-template" {
   metadata = {
     startup-script = "sudo mkdir -p /var/www && cd /var/www && echo \"hello from $(hostname)\" > index.html && python3 -m http.server 80"
   }
-  service_account_create = true
-  service_account_scopes = ["cloud-platform"]
+  service_account = {
+    auto_create = true
+    scopes      = ["cloud-platform"]
+  }
 }
 
 module "demo-backend-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v28.0.0"
   project_id        = var.project_id
   location          = var.region
   name              = "${var.name}-${var.region}"
@@ -53,7 +55,7 @@ module "demo-backend-mig" {
 }
 
 module "ilb-backend" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v28.0.0"
   project_id    = var.project_id
   region        = var.region
   name          = var.name
@@ -62,7 +64,11 @@ module "ilb-backend" {
     network    = var.network
     subnetwork = var.subnet
   }
-  ports = [80]
+  forwarding_rules_config = {
+    "" = {
+      ports = [80]
+    }
+  }
   backends = [
     {
       group          = module.demo-backend-mig.group_manager.instance_group,

--- a/modules/development-backend/outputs.tf
+++ b/modules/development-backend/outputs.tf
@@ -21,15 +21,15 @@ output "instance_group" {
 
 output "ilb_forwarding_rule_address" {
   description = "ILB forwarding rule IP address."
-  value       = module.ilb-backend.forwarding_rule_address
+  value       = module.ilb-backend.forwarding_rule_addresses[""]
 }
 
 output "ilb_forwarding_rule_self_link" {
   description = "ILB forwarding rule self link."
-  value       = module.ilb-backend.forwarding_rule_self_link
+  value       = module.ilb-backend.forwarding_rule_self_links[""]
 }
 
 output "region" {
   description = "Backend Service region."
-  value       = module.ilb-backend.forwarding_rule.region
+  value       = module.ilb-backend.forwarding_rules[""].region
 }

--- a/modules/routing-appliance/README.md
+++ b/modules/routing-appliance/README.md
@@ -10,11 +10,11 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_appliance-sa"></a> [appliance-sa](#module\_appliance-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v26.0.0 |
-| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
-| <a name="module_ilb-appliance"></a> [ilb-appliance](#module\_ilb-appliance) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
-| <a name="module_routing-appliance-mig"></a> [routing-appliance-mig](#module\_routing-appliance-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
-| <a name="module_routing-appliance-template"></a> [routing-appliance-template](#module\_routing-appliance-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
+| <a name="module_appliance-sa"></a> [appliance-sa](#module\_appliance-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v28.0.0 |
+| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v28.0.0 |
+| <a name="module_ilb-appliance"></a> [ilb-appliance](#module\_ilb-appliance) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v28.0.0 |
+| <a name="module_routing-appliance-mig"></a> [routing-appliance-mig](#module\_routing-appliance-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v28.0.0 |
+| <a name="module_routing-appliance-template"></a> [routing-appliance-template](#module\_routing-appliance-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v28.0.0 |
 
 ## Resources
 

--- a/modules/routing-appliance/README.md
+++ b/modules/routing-appliance/README.md
@@ -10,11 +10,11 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_appliance-sa"></a> [appliance-sa](#module\_appliance-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v16.0.0 |
-| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v16.0.0 |
-| <a name="module_ilb-appliance"></a> [ilb-appliance](#module\_ilb-appliance) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-ilb | v16.0.0 |
-| <a name="module_routing-appliance-mig"></a> [routing-appliance-mig](#module\_routing-appliance-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v16.0.0 |
-| <a name="module_routing-appliance-template"></a> [routing-appliance-template](#module\_routing-appliance-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v16.0.0 |
+| <a name="module_appliance-sa"></a> [appliance-sa](#module\_appliance-sa) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account | v26.0.0 |
+| <a name="module_config-bucket"></a> [config-bucket](#module\_config-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
+| <a name="module_ilb-appliance"></a> [ilb-appliance](#module\_ilb-appliance) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
+| <a name="module_routing-appliance-mig"></a> [routing-appliance-mig](#module\_routing-appliance-mig) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig | v26.0.0 |
+| <a name="module_routing-appliance-template"></a> [routing-appliance-template](#module\_routing-appliance-template) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
 
 ## Resources
 

--- a/modules/routing-appliance/main.tf
+++ b/modules/routing-appliance/main.tf
@@ -19,13 +19,13 @@ resource "random_id" "bucket" {
 }
 
 module "appliance-sa" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/iam-service-account?ref=v28.0.0"
   project_id = var.project_id
   name       = "sa-${var.name}"
 }
 
 module "config-bucket" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v28.0.0"
   project_id = var.project_id
   name       = "appliance-${random_id.bucket.dec}"
   location   = "EU"
@@ -41,7 +41,7 @@ resource "google_storage_bucket_object" "setup_script" {
 }
 
 module "routing-appliance-template" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v28.0.0"
   project_id     = var.project_id
   name           = var.name
   zone           = "${var.region}-b"
@@ -66,8 +66,10 @@ module "routing-appliance-template" {
   metadata = {
     startup-script-url = "gs://${module.config-bucket.name}/setup.sh"
   }
-  service_account        = module.appliance-sa.email
-  service_account_scopes = ["cloud-platform"]
+  service_account = {
+    email  = module.appliance-sa.email
+    scopes = ["cloud-platform"]
+  }
 
   depends_on = [
     google_storage_bucket_object.setup_script
@@ -75,7 +77,7 @@ module "routing-appliance-template" {
 }
 
 module "routing-appliance-mig" {
-  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v26.0.0"
+  source            = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-mig?ref=v28.0.0"
   project_id        = var.project_id
   location          = var.region
   name              = "${var.name}-${var.region}"
@@ -84,7 +86,7 @@ module "routing-appliance-mig" {
 }
 
 module "ilb-appliance" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v28.0.0"
   project_id    = var.project_id
   region        = var.region
   name          = var.name
@@ -93,7 +95,11 @@ module "ilb-appliance" {
     network    = var.network
     subnetwork = var.subnet
   }
-  ports = [443]
+  forwarding_rules_config = {
+    "" = {
+      ports = [443]
+    }
+  }
   backends = [
     {
       group          = module.routing-appliance-mig.group_manager.instance_group,
@@ -124,6 +130,6 @@ resource "google_compute_route" "appliance" {
   name         = "appliance-rt-${each.key}"
   dest_range   = each.value.range
   network      = var.network
-  next_hop_ilb = module.ilb-appliance.forwarding_rule.id
+  next_hop_ilb = module.ilb-appliance.forwarding_rules[""].id
   priority     = each.value.priority
 }

--- a/samples/x-basic/README.md
+++ b/samples/x-basic/README.md
@@ -55,8 +55,8 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-basic/README.md
+++ b/samples/x-basic/README.md
@@ -55,8 +55,8 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-basic/main.tf
+++ b/samples/x-basic/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = []

--- a/samples/x-basic/main.tf
+++ b/samples/x-basic/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = []
@@ -38,7 +38,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 

--- a/samples/x-controlled-internet-egress/README.md
+++ b/samples/x-controlled-internet-egress/README.md
@@ -68,10 +68,10 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_mock-firewall"></a> [mock-firewall](#module\_mock-firewall) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
-| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v26.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_mock-firewall"></a> [mock-firewall](#module\_mock-firewall) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v28.0.0 |
+| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v28.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-controlled-internet-egress/README.md
+++ b/samples/x-controlled-internet-egress/README.md
@@ -68,10 +68,10 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_mock-firewall"></a> [mock-firewall](#module\_mock-firewall) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v16.0.0 |
-| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v16.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_mock-firewall"></a> [mock-firewall](#module\_mock-firewall) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm | v26.0.0 |
+| <a name="module_nat"></a> [nat](#module\_nat) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-controlled-internet-egress/main.tf
+++ b/samples/x-controlled-internet-egress/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = [var.firewall_appliance_subnet]
@@ -38,10 +38,8 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = {
-      export = true
-      import = false
-    }
+    export_routes = true
+    import_routes = true
   }
 }
 
@@ -56,7 +54,7 @@ module "apigee-x-core" {
 }
 
 module "nat" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v16.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v26.0.0"
   project_id     = module.project.project_id
   region         = var.firewall_appliance_subnet.region
   name           = "nat"
@@ -83,7 +81,7 @@ resource "google_compute_route" "firewall_to_internet" {
 }
 
 module "mock-firewall" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v16.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
   project_id     = module.project.project_id
   zone           = var.firewall_appliance_zone
   can_ip_forward = true

--- a/samples/x-controlled-internet-egress/main.tf
+++ b/samples/x-controlled-internet-egress/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = [var.firewall_appliance_subnet]
@@ -54,7 +54,7 @@ module "apigee-x-core" {
 }
 
 module "nat" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v26.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-cloudnat?ref=v28.0.0"
   project_id     = module.project.project_id
   region         = var.firewall_appliance_subnet.region
   name           = "nat"
@@ -81,7 +81,7 @@ resource "google_compute_route" "firewall_to_internet" {
 }
 
 module "mock-firewall" {
-  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v26.0.0"
+  source         = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/compute-vm?ref=v28.0.0"
   project_id     = module.project.project_id
   zone           = var.firewall_appliance_zone
   can_ip_forward = true
@@ -92,8 +92,11 @@ module "mock-firewall" {
     nat        = false
     addresses  = null
   }]
-  tags                   = var.firewall_appliance_tags
-  service_account_create = true
+  tags = var.firewall_appliance_tags
+  service_account = {
+    auto_create = true
+    scopes      = ["cloud-platform"]
+  }
   metadata = {
     startup-script = "sysctl -w net.ipv4.ip_forward=1 && iptables -t nat -A POSTROUTING -j MASQUERADE"
   }

--- a/samples/x-dns-peering/README.md
+++ b/samples/x-dns-peering/README.md
@@ -66,9 +66,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_private-dns"></a> [private-dns](#module\_private-dns) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns | v26.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_private-dns"></a> [private-dns](#module\_private-dns) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns | v28.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-dns-peering/README.md
+++ b/samples/x-dns-peering/README.md
@@ -66,9 +66,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_private-dns"></a> [private-dns](#module\_private-dns) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns | v16.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_private-dns"></a> [private-dns](#module\_private-dns) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-dns-peering/main.tf
+++ b/samples/x-dns-peering/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -36,7 +36,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets = [{
@@ -77,7 +77,7 @@ module "backend-example" {
 }
 
 module "private-dns" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.dns.name
   zone_config = {

--- a/samples/x-dns-peering/main.tf
+++ b/samples/x-dns-peering/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -36,7 +36,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets = [{
@@ -50,7 +50,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 
@@ -78,12 +77,15 @@ module "backend-example" {
 }
 
 module "private-dns" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns?ref=v16.0.0"
-  project_id      = module.project.project_id
-  type            = "private"
-  name            = var.dns.name
-  domain          = var.dns.domain
-  client_networks = [module.vpc.self_link]
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/dns?ref=v26.0.0"
+  project_id = module.project.project_id
+  name       = var.dns.name
+  zone_config = {
+    domain = var.dns.domain
+    private = {
+      client_networks = [module.vpc.self_link]
+    }
+  }
   recordsets = merge(
     { "A ${var.backend.name}" = { type = "A", ttl = 300, records = [module.backend-example.ilb_forwarding_rule_address] } },
     { for eg_name in keys(var.apigee_envgroups) : "A ${eg_name}-api" => { type = "A", ttl = 300, records = values(module.apigee-x-core.instance_endpoints) } }

--- a/samples/x-iac-pipeline/README.md
+++ b/samples/x-iac-pipeline/README.md
@@ -149,9 +149,9 @@ curl https://test.123-456-789-012.nip.io/httpbin/headers
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_app-tfstate-bucket"></a> [app-tfstate-bucket](#module\_app-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v16.0.0 |
-| <a name="module_bootstrap-project"></a> [bootstrap-project](#module\_bootstrap-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_infra-tfstate-bucket"></a> [infra-tfstate-bucket](#module\_infra-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v16.0.0 |
+| <a name="module_app-tfstate-bucket"></a> [app-tfstate-bucket](#module\_app-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
+| <a name="module_bootstrap-project"></a> [bootstrap-project](#module\_bootstrap-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_infra-tfstate-bucket"></a> [infra-tfstate-bucket](#module\_infra-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-iac-pipeline/README.md
+++ b/samples/x-iac-pipeline/README.md
@@ -149,9 +149,9 @@ curl https://test.123-456-789-012.nip.io/httpbin/headers
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_app-tfstate-bucket"></a> [app-tfstate-bucket](#module\_app-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
-| <a name="module_bootstrap-project"></a> [bootstrap-project](#module\_bootstrap-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_infra-tfstate-bucket"></a> [infra-tfstate-bucket](#module\_infra-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v26.0.0 |
+| <a name="module_app-tfstate-bucket"></a> [app-tfstate-bucket](#module\_app-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v28.0.0 |
+| <a name="module_bootstrap-project"></a> [bootstrap-project](#module\_bootstrap-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_infra-tfstate-bucket"></a> [infra-tfstate-bucket](#module\_infra-tfstate-bucket) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-iac-pipeline/infra/main.tf
+++ b/samples/x-iac-pipeline/infra/main.tf
@@ -24,7 +24,7 @@ locals {
 }
 
 module "host-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = var.host_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -42,7 +42,7 @@ module "host-project" {
 }
 
 module "service-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = var.apigee_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -63,7 +63,7 @@ module "service-project" {
 }
 
 module "shared-vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.host-project.project_id
   name       = var.network
   psa_config = {

--- a/samples/x-iac-pipeline/infra/main.tf
+++ b/samples/x-iac-pipeline/infra/main.tf
@@ -24,7 +24,7 @@ locals {
 }
 
 module "host-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name                = var.host_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -42,7 +42,7 @@ module "host-project" {
 }
 
 module "service-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name                = var.apigee_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -63,7 +63,7 @@ module "service-project" {
 }
 
 module "shared-vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.host-project.project_id
   name       = var.network
   psa_config = {
@@ -71,22 +71,25 @@ module "shared-vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
-  subnets         = var.exposure_subnets
   shared_vpc_host = true
   shared_vpc_service_projects = [
     module.service-project.project_id
   ]
-  iam = {
+  subnets = [
     for subnet in var.exposure_subnets :
-    "${subnet.region}/${subnet.name}" =>
     {
-      "roles/compute.networkUser" = [
-        "serviceAccount:${module.service-project.service_accounts.cloud_services}"
-      ]
+      "name" = subnet.name
+      "region" = subnet.region
+      "secondary_ip_ranges" = subnet.secondary_ip_range
+      "ip_cidr_range" = subnet.ip_cidr_range
+      "iam" = {
+        "roles/compute.networkUser" = [
+          "serviceAccount:${module.service-project.service_accounts.cloud_services}"
+        ]
+      }
     }
-  }
+  ]
 }
 
 module "nip-development-hostname" {

--- a/samples/x-iac-pipeline/main.tf
+++ b/samples/x-iac-pipeline/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "bootstrap-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = var.project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -37,7 +37,7 @@ module "bootstrap-project" {
 }
 
 module "infra-tfstate-bucket" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v28.0.0"
   project_id    = module.bootstrap-project.project_id
   name          = "${var.project_id}-infra-tfstate"
   location      = var.region
@@ -47,7 +47,7 @@ module "infra-tfstate-bucket" {
 }
 
 module "app-tfstate-bucket" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v28.0.0"
   project_id    = module.bootstrap-project.project_id
   name          = "${var.project_id}-app-tfstate"
   location      = var.region

--- a/samples/x-iac-pipeline/main.tf
+++ b/samples/x-iac-pipeline/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "bootstrap-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name                = var.project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -37,7 +37,7 @@ module "bootstrap-project" {
 }
 
 module "infra-tfstate-bucket" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v16.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
   project_id    = module.bootstrap-project.project_id
   name          = "${var.project_id}-infra-tfstate"
   location      = var.region
@@ -47,7 +47,7 @@ module "infra-tfstate-bucket" {
 }
 
 module "app-tfstate-bucket" {
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v16.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/gcs?ref=v26.0.0"
   project_id    = module.bootstrap-project.project_id
   name          = "${var.project_id}-app-tfstate"
   location      = var.region

--- a/samples/x-ilb-mtls/README.md
+++ b/samples/x-ilb-mtls/README.md
@@ -88,9 +88,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_apigee-x-mtls-mig"></a> [apigee-x-mtls-mig](#module\_apigee-x-mtls-mig) | ../../modules/apigee-x-mtls-mig | n/a |
-| <a name="module_ilb"></a> [ilb](#module\_ilb) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_ilb"></a> [ilb](#module\_ilb) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v28.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-ilb-mtls/README.md
+++ b/samples/x-ilb-mtls/README.md
@@ -88,9 +88,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_apigee-x-mtls-mig"></a> [apigee-x-mtls-mig](#module\_apigee-x-mtls-mig) | ../../modules/apigee-x-mtls-mig | n/a |
-| <a name="module_ilb"></a> [ilb](#module\_ilb) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-ilb | v16.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_ilb"></a> [ilb](#module\_ilb) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-ilb-mtls/main.tf
+++ b/samples/x-ilb-mtls/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets
@@ -73,7 +73,7 @@ module "apigee-x-mtls-mig" {
 
 module "ilb" {
   for_each      = var.apigee_instances
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v26.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v28.0.0"
   project_id    = module.project.project_id
   region        = each.value.region
   name          = "apigee-mtls-${each.key}"
@@ -82,7 +82,11 @@ module "ilb" {
     network    = module.vpc.network.id
     subnetwork = module.vpc.subnet_self_links[local.subnet_region_name[each.value.region]]
   }
-  ports = [443]
+  forwarding_rules_config = {
+    "" = {
+      ports = [443]
+    }
+  }
   backends = [
     {
       group          = module.apigee-x-mtls-mig[each.key].instance_group,

--- a/samples/x-ilb-mtls/main.tf
+++ b/samples/x-ilb-mtls/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets
@@ -44,7 +44,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 
@@ -74,14 +73,16 @@ module "apigee-x-mtls-mig" {
 
 module "ilb" {
   for_each      = var.apigee_instances
-  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-ilb?ref=v16.0.0"
+  source        = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-lb-int?ref=v26.0.0"
   project_id    = module.project.project_id
   region        = each.value.region
   name          = "apigee-mtls-${each.key}"
   service_label = "apigee-mtls-${each.key}"
-  network       = module.vpc.network.id
-  subnetwork    = module.vpc.subnet_self_links[local.subnet_region_name[each.value.region]]
-  ports         = [443]
+  vpc_config = {
+    network    = module.vpc.network.id
+    subnetwork = module.vpc.subnet_self_links[local.subnet_region_name[each.value.region]]
+  }
+  ports = [443]
   backends = [
     {
       group          = module.apigee-x-mtls-mig[each.key].instance_group,
@@ -90,10 +91,7 @@ module "ilb" {
     }
   ]
   health_check_config = {
-    type    = "tcp"
-    check   = { port = 443 }
-    config  = {}
-    logging = true
+    tcp = { port = 443 }
   }
 }
 

--- a/samples/x-l4xlb-mtls/README.md
+++ b/samples/x-l4xlb-mtls/README.md
@@ -110,8 +110,8 @@ curl https://my-domain.com/my-proxy --cert ./certs/example-client.crt --key ./ce
 | <a name="module_apigee-x-mtls-mig"></a> [apigee-x-mtls-mig](#module\_apigee-x-mtls-mig) | ../../modules/apigee-x-mtls-mig | n/a |
 | <a name="module_mig-l4xlb"></a> [mig-l4xlb](#module\_mig-l4xlb) | ../../modules/l4xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-l4xlb-mtls/README.md
+++ b/samples/x-l4xlb-mtls/README.md
@@ -110,8 +110,8 @@ curl https://my-domain.com/my-proxy --cert ./certs/example-client.crt --key ./ce
 | <a name="module_apigee-x-mtls-mig"></a> [apigee-x-mtls-mig](#module\_apigee-x-mtls-mig) | ../../modules/apigee-x-mtls-mig | n/a |
 | <a name="module_mig-l4xlb"></a> [mig-l4xlb](#module\_mig-l4xlb) | ../../modules/l4xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-l4xlb-mtls/main.tf
+++ b/samples/x-l4xlb-mtls/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets
@@ -44,7 +44,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 

--- a/samples/x-l4xlb-mtls/main.tf
+++ b/samples/x-l4xlb-mtls/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets

--- a/samples/x-l7xlb/README.md
+++ b/samples/x-l7xlb/README.md
@@ -59,8 +59,8 @@ No providers.
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-l7xlb/README.md
+++ b/samples/x-l7xlb/README.md
@@ -59,8 +59,8 @@ No providers.
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-l7xlb/main.tf
+++ b/samples/x-l7xlb/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets
@@ -44,7 +44,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 

--- a/samples/x-l7xlb/main.tf
+++ b/samples/x-l7xlb/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = var.exposure_subnets

--- a/samples/x-multi-region/README.md
+++ b/samples/x-multi-region/README.md
@@ -60,11 +60,11 @@ No providers.
 |------|--------|---------|
 | <a name="module_apigee-x-bridge-mig"></a> [apigee-x-bridge-mig](#module\_apigee-x-bridge-mig) | ../../modules/apigee-x-bridge-mig | n/a |
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-multi-region/README.md
+++ b/samples/x-multi-region/README.md
@@ -60,11 +60,11 @@ No providers.
 |------|--------|---------|
 | <a name="module_apigee-x-bridge-mig"></a> [apigee-x-bridge-mig](#module\_apigee-x-bridge-mig) | ../../modules/apigee-x-bridge-mig | n/a |
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
+| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-multi-region/main.tf
+++ b/samples/x-multi-region/main.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 module "host-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = local.svpc_host_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -41,7 +41,7 @@ module "host-project" {
 }
 
 module "service-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = var.project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -61,7 +61,7 @@ module "service-project" {
 }
 
 module "shared-vpc" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id      = module.host-project.project_id
   name            = var.network
   shared_vpc_host = true

--- a/samples/x-multi-region/main.tf
+++ b/samples/x-multi-region/main.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 module "host-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name                = local.svpc_host_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -41,7 +41,7 @@ module "host-project" {
 }
 
 module "service-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name                = var.project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -61,29 +61,32 @@ module "service-project" {
 }
 
 module "shared-vpc" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id      = module.host-project.project_id
   name            = var.network
-  subnets         = var.exposure_subnets
   shared_vpc_host = true
   shared_vpc_service_projects = [
     module.service-project.project_id
   ]
-  iam = {
+  subnets = [
     for subnet in var.exposure_subnets :
-    "${subnet.region}/${subnet.name}" =>
     {
-      "roles/compute.networkUser" = [
-        "serviceAccount:${module.service-project.service_accounts.cloud_services}"
-      ]
+      "name"                = subnet.name
+      "region"              = subnet.region
+      "secondary_ip_ranges" = subnet.secondary_ip_range
+      "ip_cidr_range"       = subnet.ip_cidr_range
+      "iam" = {
+        "roles/compute.networkUser" = [
+          "serviceAccount:${module.service-project.service_accounts.cloud_services}"
+        ]
+      }
     }
-  }
+  ]
   psa_config = {
     ranges = {
       apigee-range          = var.peering_range
       apigee-support-range1 = var.support_range1
     }
-    routes = null
   }
 }
 

--- a/samples/x-nb-psc-l7ilb/README.md
+++ b/samples/x-nb-psc-l7ilb/README.md
@@ -58,9 +58,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_nb-psc-l7ilb"></a> [nb-psc-l7ilb](#module\_nb-psc-l7ilb) | ../../modules/nb-psc-l7ilb | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-nb-psc-l7ilb/README.md
+++ b/samples/x-nb-psc-l7ilb/README.md
@@ -58,9 +58,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_nb-psc-l7ilb"></a> [nb-psc-l7ilb](#module\_nb-psc-l7ilb) | ../../modules/nb-psc-l7ilb | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-nb-psc-l7ilb/main.tf
+++ b/samples/x-nb-psc-l7ilb/main.tf
@@ -38,7 +38,7 @@ locals {
 
 # GCP Project to host Apigee Organization and the related components.
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -53,7 +53,7 @@ module "project" {
 
 # VPC Network to host Apigee Organization network resources.
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   psa_config = {
@@ -61,7 +61,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 
@@ -83,7 +82,7 @@ module "apigee-x-core" {
 
 # VPC for Private Service Connect-based Ingress.
 module "psc-ingress-vpc" {
-  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id              = module.project.project_id
   name                    = var.psc_ingress_network
   auto_create_subnetworks = false

--- a/samples/x-nb-psc-l7ilb/main.tf
+++ b/samples/x-nb-psc-l7ilb/main.tf
@@ -38,7 +38,7 @@ locals {
 
 # GCP Project to host Apigee Organization and the related components.
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -53,7 +53,7 @@ module "project" {
 
 # VPC Network to host Apigee Organization network resources.
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   psa_config = {
@@ -82,7 +82,7 @@ module "apigee-x-core" {
 
 # VPC for Private Service Connect-based Ingress.
 module "psc-ingress-vpc" {
-  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id              = module.project.project_id
   name                    = var.psc_ingress_network
   auto_create_subnetworks = false

--- a/samples/x-nb-psc-xlb/README.md
+++ b/samples/x-nb-psc-xlb/README.md
@@ -59,9 +59,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_nb-psc-l7xlb"></a> [nb-psc-l7xlb](#module\_nb-psc-l7xlb) | ../../modules/nb-psc-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-nb-psc-xlb/README.md
+++ b/samples/x-nb-psc-xlb/README.md
@@ -59,9 +59,9 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_nb-psc-l7xlb"></a> [nb-psc-l7xlb](#module\_nb-psc-l7xlb) | ../../modules/nb-psc-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_psc-ingress-vpc"></a> [psc-ingress-vpc](#module\_psc-ingress-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-nb-psc-xlb/main.tf
+++ b/samples/x-nb-psc-xlb/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   psa_config = {
@@ -68,7 +68,7 @@ module "apigee-x-core" {
 }
 
 module "psc-ingress-vpc" {
-  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id              = module.project.project_id
   name                    = var.psc_ingress_network
   auto_create_subnetworks = false

--- a/samples/x-nb-psc-xlb/main.tf
+++ b/samples/x-nb-psc-xlb/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -35,7 +35,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   psa_config = {
@@ -43,7 +43,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 
@@ -69,7 +68,7 @@ module "apigee-x-core" {
 }
 
 module "psc-ingress-vpc" {
-  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source                  = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id              = module.project.project_id
   name                    = var.psc_ingress_network
   auto_create_subnetworks = false

--- a/samples/x-sb-psc/README.md
+++ b/samples/x-sb-psc/README.md
@@ -71,10 +71,10 @@ psc_endpoint_attachment_connection_state = "ACCEPTED"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
+| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
 | <a name="module_southbound-psc"></a> [southbound-psc](#module\_southbound-psc) | ../../modules/sb-psc-attachment | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-sb-psc/README.md
+++ b/samples/x-sb-psc/README.md
@@ -71,10 +71,10 @@ psc_endpoint_attachment_connection_state = "ACCEPTED"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
 | <a name="module_southbound-psc"></a> [southbound-psc](#module\_southbound-psc) | ../../modules/sb-psc-attachment | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-sb-psc/main.tf
+++ b/samples/x-sb-psc/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = []
@@ -52,7 +52,7 @@ module "apigee-x-core" {
 }
 
 module "backend-vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.backend_network
   subnets = [

--- a/samples/x-sb-psc/main.tf
+++ b/samples/x-sb-psc/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v16.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.network
   subnets    = []
@@ -38,7 +38,6 @@ module "vpc" {
       apigee-range         = var.peering_range
       apigee-support-range = var.support_range
     }
-    routes = null
   }
 }
 
@@ -53,7 +52,7 @@ module "apigee-x-core" {
 }
 
 module "backend-vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v16.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
   project_id = module.project.project_id
   name       = var.backend_network
   subnets = [

--- a/samples/x-shared-vpc/README.md
+++ b/samples/x-shared-vpc/README.md
@@ -56,11 +56,11 @@ No providers.
 |------|--------|---------|
 | <a name="module_apigee-x-bridge-mig"></a> [apigee-x-bridge-mig](#module\_apigee-x-bridge-mig) | ../../modules/apigee-x-bridge-mig | n/a |
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
-| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
+| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-shared-vpc/README.md
+++ b/samples/x-shared-vpc/README.md
@@ -56,11 +56,11 @@ No providers.
 |------|--------|---------|
 | <a name="module_apigee-x-bridge-mig"></a> [apigee-x-bridge-mig](#module\_apigee-x-bridge-mig) | ../../modules/apigee-x-bridge-mig | n/a |
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
-| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
+| <a name="module_host-project"></a> [host-project](#module\_host-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
 | <a name="module_mig-l7xlb"></a> [mig-l7xlb](#module\_mig-l7xlb) | ../../modules/mig-l7xlb | n/a |
 | <a name="module_nip-development-hostname"></a> [nip-development-hostname](#module\_nip-development-hostname) | ../../modules/nip-development-hostname | n/a |
-| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
-| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_service-project"></a> [service-project](#module\_service-project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_shared-vpc"></a> [shared-vpc](#module\_shared-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-shared-vpc/main.tf
+++ b/samples/x-shared-vpc/main.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 module "host-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = local.svpc_host_project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -38,7 +38,7 @@ module "host-project" {
 }
 
 module "service-project" {
-  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source              = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name                = var.project_id
   parent              = var.project_parent
   billing_account     = var.billing_account
@@ -58,7 +58,7 @@ module "service-project" {
 }
 
 module "shared-vpc" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id      = module.host-project.project_id
   name            = var.network
   shared_vpc_host = true

--- a/samples/x-transitive-peering/README.md
+++ b/samples/x-transitive-peering/README.md
@@ -75,11 +75,11 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
-| <a name="module_peering-apigee-backend"></a> [peering-apigee-backend](#module\_peering-apigee-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering | v16.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v16.0.0 |
+| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_peering-apigee-backend"></a> [peering-apigee-backend](#module\_peering-apigee-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering | v26.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
 | <a name="module_routing-appliance"></a> [routing-appliance](#module\_routing-appliance) | ../../modules/routing-appliance | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v16.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
 
 ## Resources
 

--- a/samples/x-transitive-peering/README.md
+++ b/samples/x-transitive-peering/README.md
@@ -75,11 +75,11 @@ terraform apply --var-file=./my-config.tfvars -var "project_id=$PROJECT_ID"
 |------|--------|---------|
 | <a name="module_apigee-x-core"></a> [apigee-x-core](#module\_apigee-x-core) | ../../modules/apigee-x-core | n/a |
 | <a name="module_backend-example"></a> [backend-example](#module\_backend-example) | ../../modules/development-backend | n/a |
-| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
-| <a name="module_peering-apigee-backend"></a> [peering-apigee-backend](#module\_peering-apigee-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering | v26.0.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v26.0.0 |
+| <a name="module_backend-vpc"></a> [backend-vpc](#module\_backend-vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
+| <a name="module_peering-apigee-backend"></a> [peering-apigee-backend](#module\_peering-apigee-backend) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering | v28.0.0 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/project | v28.0.0 |
 | <a name="module_routing-appliance"></a> [routing-appliance](#module\_routing-appliance) | ../../modules/routing-appliance | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v26.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc | v28.0.0 |
 
 ## Resources
 

--- a/samples/x-transitive-peering/main.tf
+++ b/samples/x-transitive-peering/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "project" {
-  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v26.0.0"
+  source          = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/project?ref=v28.0.0"
   name            = var.project_id
   parent          = var.project_parent
   billing_account = var.billing_account
@@ -29,7 +29,7 @@ module "project" {
 }
 
 module "vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.apigee_network
   subnets    = [var.appliance_subnet]
@@ -76,14 +76,14 @@ resource "google_compute_firewall" "allow-appliance-ingress" {
 }
 
 module "backend-vpc" {
-  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v26.0.0"
+  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc?ref=v28.0.0"
   project_id = module.project.project_id
   name       = var.backend_network
   subnets    = [var.backend_subnet]
 }
 
 module "peering-apigee-backend" {
-  source = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering?ref=v26.0.0"
+  source = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/net-vpc-peering?ref=v28.0.0"
   prefix = "peering-apigee-backend"
 
   local_network = module.vpc.self_link

--- a/tests/samples/test_controlled_internet_egress.py
+++ b/tests/samples/test_controlled_internet_egress.py
@@ -34,7 +34,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 36
+    assert len(resources) == 39
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_controlled_internet_egress.py
+++ b/tests/samples/test_controlled_internet_egress.py
@@ -44,7 +44,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_dns_peering.py
+++ b/tests/samples/test_dns_peering.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 46
+    assert len(resources) == 45
 
 
 def test_apigee_instance(resources):
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_dns_peering.py
+++ b/tests/samples/test_dns_peering.py
@@ -28,13 +28,12 @@ def resources(recursive_plan_runner):
         project_id="testonly",
         project_create="true"
     )
-    print(json.dumps(resources,indent=2))
     return resources
 
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 42
+    assert len(resources) == 46
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_iac_pipeline.py
+++ b/tests/samples/test_iac_pipeline.py
@@ -36,4 +36,4 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 22
+    assert len(resources) == 24

--- a/tests/samples/test_ilb_mtls.py
+++ b/tests/samples/test_ilb_mtls.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 46
+    assert len(resources) == 49
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_ilb_mtls.py
+++ b/tests/samples/test_ilb_mtls.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_l4xlb_mtls.py
+++ b/tests/samples/test_l4xlb_mtls.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 49
+    assert len(resources) == 52
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_l4xlb_mtls.py
+++ b/tests/samples/test_l4xlb_mtls.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 def test_envgroup_attachment(resources):
     "Test Apigee Envgroup Attachments."

--- a/tests/samples/test_l7xlb.py
+++ b/tests/samples/test_l7xlb.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_l7xlb.py
+++ b/tests/samples/test_l7xlb.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 41
+    assert len(resources) == 44
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_multi_region.py
+++ b/tests/samples/test_multi_region.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 57
+    assert len(resources) == 60
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_multi_region.py
+++ b/tests/samples/test_multi_region.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_nb_psc_xlb.py
+++ b/tests/samples/test_nb_psc_xlb.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 37
+    assert len(resources) == 42
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_nb_psc_xlb.py
+++ b/tests/samples/test_nb_psc_xlb.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_sb_psc.py
+++ b/tests/samples/test_sb_psc.py
@@ -44,7 +44,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_sb_psc.py
+++ b/tests/samples/test_sb_psc.py
@@ -34,7 +34,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 41
+    assert len(resources) == 46
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_shared_vpc.py
+++ b/tests/samples/test_shared_vpc.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 50
+    assert len(resources) == 53
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_shared_vpc.py
+++ b/tests/samples/test_shared_vpc.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_transtive_peering.py
+++ b/tests/samples/test_transtive_peering.py
@@ -35,7 +35,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 55
+    assert len(resources) == 60
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_transtive_peering.py
+++ b/tests/samples/test_transtive_peering.py
@@ -45,7 +45,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1","test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/test_x_basic.py
+++ b/tests/samples/test_x_basic.py
@@ -33,7 +33,7 @@ def resources(recursive_plan_runner):
 
 def test_resource_count(resources):
     "Test total number of resources created."
-    assert len(resources) == 28
+    assert len(resources) == 31
 
 
 def test_apigee_instance(resources):

--- a/tests/samples/test_x_basic.py
+++ b/tests/samples/test_x_basic.py
@@ -43,7 +43,7 @@ def test_apigee_instance(resources):
 
 def test_apigee_instance_attachment(resources):
     "Test Apigee Instance Attachments."
-    assert_instance_attachment(resources, ["test1-europe-west1", "test2-europe-west1"])
+    assert_instance_attachment(resources, ["europe-west1-test1", "europe-west1-test2"])
 
 
 def test_envgroup_attachment(resources):

--- a/tests/samples/utils.py
+++ b/tests/samples/utils.py
@@ -48,6 +48,7 @@ def assert_instance_attachment(resources, attachment_ids):
     attachments = resources_by_type(resources, "google_apigee_instance_attachment")
     assert len(attachments) == len(attachment_ids)
     attachment_ids_found = set(a["index"] for a in attachments)
+    print(attachment_ids_found)
     assert set(attachment_ids_found) == set(attachment_ids)
 
 def resources_by_type(resources, resourceType):


### PR DESCRIPTION
What's changed, or what was fixed?

- All CFF dependencies bumped from [v16.0.0](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/releases/tag/v16.0.0) to [v28.0.0](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/releases/tag/v28.0.0)
  - **Breaking Change** the upstream CFF [reversed the order of the env-instance attachment ids](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/commit/8469c86e63c0c0aaba055438e9f8c5b35cd63b9d) for this reason the attachments will be removed and re-added upon apply.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.