### PR TITLE
feat: adding target server to sb-psc-attachment module

### DIFF
--- a/modules/sb-psc-attachment/README.md
+++ b/modules/sb-psc-attachment/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.20.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.83, <6 |
 
 ## Modules
 
@@ -14,6 +14,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_apigee_endpoint_attachment.endpoint_attachment](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/apigee_endpoint_attachment) | resource |
+| [google_apigee_target_server.target_server](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/apigee_target_server) | resource |
 | [google_compute_service_attachment.psc_service_attachment](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_service_attachment) | resource |
 
 ## Inputs
@@ -25,6 +26,7 @@ No modules.
 | <a name="input_nat_subnets"></a> [nat\_subnets](#input\_nat\_subnets) | One or more NAT subnets to be used for PSC. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP region where the service attachment should be created. | `string` | n/a | yes |
+| <a name="input_target_servers"></a> [target\_servers](#input\_target\_servers) | Map of target servers to be created and associated with the endpoint attachment. | <pre>map(object({<br>    environment_id = string<br>    name           = string<br>    protocol       = optional(string, "HTTP")<br>    port           = optional(number, 80)<br>    enabled        = optional(bool, true)<br>    s_sl_info = optional(object({<br>      enabled                  = bool<br>      client_auth_enabled      = optional(bool, null)<br>      key_store                = optional(string, null)<br>      key_alias                = optional(string, null)<br>      trust_store              = optional(string, null)<br>      ignore_validation_errors = optional(bool, null)<br>      protocols                = optional(list(string), null)<br>      ciphers                  = optional(list(string), null)<br>      common_name = optional(object({<br>        value          = optional(string, null)<br>        wildcard_match = optional(bool, null)<br>      }))<br>    }))<br>  }))</pre> | `{}` | no |
 | <a name="input_target_service"></a> [target\_service](#input\_target\_service) | Target Service for the service attachment e.g. a forwarding rule. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/sb-psc-attachment/main.tf
+++ b/modules/sb-psc-attachment/main.tf
@@ -32,3 +32,37 @@ resource "google_apigee_endpoint_attachment" "endpoint_attachment" {
   location               = var.region
   service_attachment     = google_compute_service_attachment.psc_service_attachment.id
 }
+
+
+resource "google_apigee_target_server" "target_server" {
+  for_each = var.target_servers
+
+  name        = each.value.name
+  description = "Target server for ${var.name} endpoint attachment"
+  env_id      = each.value.environment_id
+  protocol    = each.value.protocol
+  host        = google_apigee_endpoint_attachment.endpoint_attachment.host
+  port        = each.value.port
+  is_enabled  = each.value.enabled
+
+  dynamic "s_sl_info" {
+    for_each = each.value.s_sl_info != null ? [1] : []
+    content {
+      enabled                  = each.value.s_sl_info.enabled
+      client_auth_enabled      = each.value.s_sl_info.client_auth_enabled
+      key_store                = each.value.s_sl_info.key_store
+      key_alias                = each.value.s_sl_info.key_alias
+      trust_store              = each.value.s_sl_info.trust_store
+      ignore_validation_errors = each.value.s_sl_info.ignore_validation_errors
+      protocols                = each.value.s_sl_info.protocols
+      ciphers                  = each.value.s_sl_info.ciphers
+      dynamic "common_name" {
+        for_each = each.value.s_sl_info.common_name != null ? [1] : []
+        content {
+          value          = each.value.s_sl_info.common_name.value
+          wildcard_match = each.value.s_sl_info.common_name.wildcard_match
+        }
+      }
+    }
+  }
+}

--- a/modules/sb-psc-attachment/variables.tf
+++ b/modules/sb-psc-attachment/variables.tf
@@ -47,3 +47,29 @@ variable "apigee_organization" {
     error_message = "Invalid Apigee Organization ID. Please use the format \"organizations/[a-zA-Z0-9-_]+\"."
   }
 }
+
+variable "target_servers" {
+  description = "Map of target servers to be created and associated with the endpoint attachment."
+  default     = {}
+  type = map(object({
+    environment_id = string
+    name           = string
+    protocol       = optional(string, "HTTP")
+    port           = optional(number, 80)
+    enabled        = optional(bool, true)
+    s_sl_info = optional(object({
+      enabled                  = bool
+      client_auth_enabled      = optional(bool, null)
+      key_store                = optional(string, null)
+      key_alias                = optional(string, null)
+      trust_store              = optional(string, null)
+      ignore_validation_errors = optional(bool, null)
+      protocols                = optional(list(string), null)
+      ciphers                  = optional(list(string), null)
+      common_name = optional(object({
+        value          = optional(string, null)
+        wildcard_match = optional(bool, null)
+      }))
+    }))
+  }))
+}

--- a/modules/sb-psc-attachment/versions.tf
+++ b/modules/sb-psc-attachment/versions.tf
@@ -15,15 +15,15 @@
  */
 
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.3.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.20.0"
+      version = ">= 4.83, <6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.20.0"
+      version = ">= 4.83, <6"
     }
   }
 }

--- a/samples/x-iac-pipeline/infra/main.tf
+++ b/samples/x-iac-pipeline/infra/main.tf
@@ -79,10 +79,10 @@ module "shared-vpc" {
   subnets = [
     for subnet in var.exposure_subnets :
     {
-      "name" = subnet.name
-      "region" = subnet.region
+      "name"                = subnet.name
+      "region"              = subnet.region
       "secondary_ip_ranges" = subnet.secondary_ip_range
-      "ip_cidr_range" = subnet.ip_cidr_range
+      "ip_cidr_range"       = subnet.ip_cidr_range
       "iam" = {
         "roles/compute.networkUser" = [
           "serviceAccount:${module.service-project.service_accounts.cloud_services}"


### PR DESCRIPTION
What's changed, or what was fixed?

- Since version 5 of the terraform gcp providers, we have google_apigee_target_server resource available. I have it integrated in the current sb-psc module as an extra capability, so that we can mange it all in one

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.