### PR TITLE
[Fix] Failed to recreate APigee organisation in the same Project

### DIFF
--- a/modules/apigee-x-core/main.tf
+++ b/modules/apigee-x-core/main.tf
@@ -31,6 +31,14 @@ resource "google_project_service_identity" "apigee_sa" {
   service  = "apigee.googleapis.com"
 }
 
+
+
+resource "random_string" "key_random_suffix" {
+  length  = 6
+  special = false
+}
+
+
 module "kms-org-db" {
   source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v28.0.0"
   project_id = var.project_id
@@ -39,7 +47,8 @@ module "kms-org-db" {
   }
   keyring = {
     location = coalesce(var.org_kms_keyring_location, var.ax_region)
-    name     = var.org_kms_keyring_name
+  
+     name     = "${var.org_kms_keyring_name}-${random_string.key_random_suffix.result}"
   }
   keyring_create = var.org_kms_keyring_create
   keys = {
@@ -56,7 +65,8 @@ module "kms-inst-disk" {
   }
   keyring = {
     location = coalesce(each.value.keyring_location, each.value.region)
-    name     = coalesce(each.value.keyring_name, "apigee-${each.key}")
+    name     = "${coalesce(each.value.keyring_name, "apigee-${each.key}")}-${random_string.key_random_suffix.result}"
+  
   }
   keyring_create = each.value.keyring_create
   keys = {


### PR DESCRIPTION
[Fix] Failed to recreate APigee organisation in the same Project #155

Once an Apigee organization is created in a specific project, two resources (Key Rings) are also created within that project. These resources are managed by the **apigee-x-core** module, specifically  the **_kms-org-db_** and _**kms-inst-disk**_ . However, when you destroy the environment using the **`terraform destroy`** command, these two resources are not deleted permanently because of GCP limitation     

> KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it from state but will not delete the resource from the project.  for more details pls check out this link: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring 


When running `terraform apply` again to recreate the apigee in the same project  , you might encounter the following error:


<pre style="color:red;">
Error: Error creating KeyRing: googleapi: Error 409: KeyRing projects/bespin-apigee-test-2-433209/locations/me-central2/keyRings/apigee-instance already exists.
with module.apigee-x-core.module.kms-inst-disk["instance"].google_kms_key_ring.default[0], on .terraform/modules/apigee-x-core.kms-inst-disk/modules/kms/main.tf line 32, in resource "google_kms_key_ring" "default":
32: resource "google_kms_key_ring" "default" {

Error: Error creating KeyRing: googleapi: Error 409: KeyRing projects/bespin-apigee-test-2-433209/locations/me-central2/keyRings/apigee-x-org already exists.
with module.apigee-x-core.module.kms-org-db.google_kms_key_ring.default[0],
on .terraform/modules/apigee-x-core.kms-org-db/modules/kms/main.tf line 32, in resource "google_kms_key_ring" "default":
32: resource "google_kms_key_ring" "default" {
</pre>

The solution to remove the project and create the Apigee in a new project is not considered best practice. To address this issue, We can add a `random_string` resource and use it as a postfix in the names of these two resources as shown below.


```yaml
resource "random_string" "key_random_suffix" {
  length  = 6
  special = false
}


module "kms-org-db" {
  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v28.0.0"
  project_id = var.project_id
  iam = {
    "roles/cloudkms.cryptoKeyEncrypterDecrypter" = ["serviceAccount:${google_project_service_identity.apigee_sa.email}"]
  }
  keyring = {
    location = coalesce(var.org_kms_keyring_location, var.ax_region)
    # name     = var.org_kms_keyring_name --> delete this line
     name     = "${var.org_kms_keyring_name}-${random_string.key_random_suffix.result}"
  }
  keyring_create = var.org_kms_keyring_create
  keys = {
    org-db = { rotation_period = var.org_key_rotation_period, labels = null }
  }
}

module "kms-inst-disk" {
  for_each   = var.apigee_instances
  source     = "github.com/terraform-google-modules/cloud-foundation-fabric//modules/kms?ref=v28.0.0"
  project_id = var.project_id
  iam = {
    "roles/cloudkms.cryptoKeyEncrypterDecrypter" = ["serviceAccount:${google_project_service_identity.apigee_sa.email}"]
  }
  keyring = {
    location = coalesce(each.value.keyring_location, each.value.region)
    name     = "${coalesce(each.value.keyring_name, "apigee-${each.key}")}-${random_string.key_random_suffix.result}"
   # name     = coalesce(each.value.keyring_name, "apigee-${each.key}") --> delete this line
  }
  keyring_create = each.value.keyring_create
  keys = {
    (each.value.key_name) = {
      rotation_period = each.value.key_rotation_period
      labels          = each.value.key_labels
    }
  }
}
